### PR TITLE
fix docker action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,6 @@
 name: Docker
 
-on:
-  push:
-    branches: master
+on: [push]
 
 jobs:
   github-cache:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,8 @@
 name: Docker
 
-on: [push]
+on: 
+  push:
+    branches: main
 
 jobs:
   github-cache:


### PR DESCRIPTION
Kind of a silly mistake. The workflow was configured to use the `master` branch but github now uses `main` as the default branch.

- retest with hook set to on push
- fix workflow as github no longer uses master but rather main
