### PR TITLE
increase block time to the standard 6 seconds

### DIFF
--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -34,7 +34,7 @@ pub mod time {
     /// `SLOT_DURATION` should have the same value.
     ///
     /// <https://research.web3.foundation/en/latest/polkadot/block-production/Babe.html#-6.-practical-results>
-    pub const MILLISECS_PER_BLOCK: Moment = 3000;
+    pub const MILLISECS_PER_BLOCK: Moment = 6000;
     pub const SECS_PER_BLOCK: Moment = MILLISECS_PER_BLOCK / 1000;
 
     pub const SLOT_DURATION: Moment = MILLISECS_PER_BLOCK;

--- a/runtime/src/version.rs
+++ b/runtime/src/version.rs
@@ -16,7 +16,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // and set impl_version to 0. If only runtime
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
-    spec_version: 0,
+    spec_version: 1,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Chaos net authorities are having issues following when running on the DO servers. Bump the testing 3s value to 6s to better fit other known working deployments/
