### PR TITLE
Marko/migrate pallets to frame v2

### DIFF
--- a/pallets/marketplace/src/benchmarking.rs
+++ b/pallets/marketplace/src/benchmarking.rs
@@ -1,7 +1,6 @@
-use crate::NFTsForSale;
-use crate::{Call, Config, Module, NFTIdOf};
+use crate::pallet::NFTIdOf;
+use crate::{Call, Config, Module, NFTsForSale};
 use frame_benchmarking::{benchmarks, whitelisted_caller};
-use frame_support::StorageMap;
 use frame_system::RawOrigin;
 use sp_std::{boxed::Box, prelude::*};
 use ternoa_common::traits::NFTs;

--- a/pallets/marketplace/src/benchmarking.rs
+++ b/pallets/marketplace/src/benchmarking.rs
@@ -1,5 +1,4 @@
-use crate::pallet::NFTIdOf;
-use crate::{Call, Config, Module, NFTsForSale};
+use crate::{Call, Config, Module, NFTIdOf, NFTsForSale};
 use frame_benchmarking::{benchmarks, whitelisted_caller};
 use frame_system::RawOrigin;
 use sp_std::{boxed::Box, prelude::*};

--- a/pallets/marketplace/src/lib.rs
+++ b/pallets/marketplace/src/lib.rs
@@ -19,14 +19,10 @@ pub trait WeightInfo {
 
 #[frame_support::pallet]
 pub mod pallet {
-    use super::WeightInfo;
-
-    use frame_support::pallet_prelude::{
-        ensure, Blake2_128Concat, DispatchResultWithPostInfo, Hooks, IsType, PhantomData,
-        StorageMap, ValueQuery,
-    };
+    use super::*;
+    use frame_support::pallet_prelude::*;
     use frame_support::traits::{Currency, ExistenceRequirement};
-    use frame_system::pallet_prelude::{ensure_signed, BlockNumberFor, OriginFor};
+    use frame_system::pallet_prelude::*;
     use ternoa_common::traits::{LockableNFTs, NFTs};
 
     pub type BalanceOf<T> =

--- a/pallets/marketplace/src/lib.rs
+++ b/pallets/marketplace/src/lib.rs
@@ -42,32 +42,6 @@ pub mod pallet {
         type WeightInfo: WeightInfo;
     }
 
-    #[pallet::event]
-    #[pallet::generate_deposit(pub(super) fn deposit_event)]
-    #[pallet::metadata(T::AccountId = "AccountId", NFTIdOf<T> = "NFTId", BalanceOf<T> = "Balance")]
-    pub enum Event<T: Config> {
-        /// A nft has been listed for sale. \[nft id, price\]
-        NftListed(NFTIdOf<T>, BalanceOf<T>),
-        /// A nft is removed from the marketplace by its owner. \[nft id\]
-        NftUnlisted(NFTIdOf<T>),
-        /// A nft has been sold. \[nft id, new owner\]
-        NftSold(NFTIdOf<T>, T::AccountId),
-    }
-
-    #[pallet::error]
-    pub enum Error<T> {
-        /// This function is reserved to the owner of a nft.
-        NotNftOwner,
-        /// Nft is not present on the marketplace
-        NftNotForSale,
-    }
-
-    /// Nfts listed on the marketplace
-    #[pallet::storage]
-    #[pallet::getter(fn nft_for_sale)]
-    pub type NFTsForSale<T: Config> =
-        StorageMap<_, Blake2_128Concat, NFTIdOf<T>, (T::AccountId, BalanceOf<T>), ValueQuery>;
-
     #[pallet::pallet]
     #[pallet::generate_store(pub(super) trait Store)]
     pub struct Pallet<T>(PhantomData<T>);
@@ -134,4 +108,30 @@ pub mod pallet {
             Ok(().into())
         }
     }
+
+    #[pallet::event]
+    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    #[pallet::metadata(T::AccountId = "AccountId", NFTIdOf<T> = "NFTId", BalanceOf<T> = "Balance")]
+    pub enum Event<T: Config> {
+        /// A nft has been listed for sale. \[nft id, price\]
+        NftListed(NFTIdOf<T>, BalanceOf<T>),
+        /// A nft is removed from the marketplace by its owner. \[nft id\]
+        NftUnlisted(NFTIdOf<T>),
+        /// A nft has been sold. \[nft id, new owner\]
+        NftSold(NFTIdOf<T>, T::AccountId),
+    }
+
+    #[pallet::error]
+    pub enum Error<T> {
+        /// This function is reserved to the owner of a nft.
+        NotNftOwner,
+        /// Nft is not present on the marketplace
+        NftNotForSale,
+    }
+
+    /// Nfts listed on the marketplace
+    #[pallet::storage]
+    #[pallet::getter(fn nft_for_sale)]
+    pub type NFTsForSale<T: Config> =
+        StorageMap<_, Blake2_128Concat, NFTIdOf<T>, (T::AccountId, BalanceOf<T>), ValueQuery>;
 }

--- a/pallets/marketplace/src/lib.rs
+++ b/pallets/marketplace/src/lib.rs
@@ -29,9 +29,9 @@ pub mod pallet {
     use frame_system::pallet_prelude::{ensure_signed, BlockNumberFor, OriginFor};
     use ternoa_common::traits::{LockableNFTs, NFTs};
 
-    type BalanceOf<T> =
+    pub type BalanceOf<T> =
         <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
-    type NFTIdOf<T> = <<T as Config>::NFTs as LockableNFTs>::NFTId;
+    pub type NFTIdOf<T> = <<T as Config>::NFTs as LockableNFTs>::NFTId;
 
     #[pallet::config]
     pub trait Config: frame_system::Config {

--- a/pallets/marketplace/src/lib.rs
+++ b/pallets/marketplace/src/lib.rs
@@ -1,13 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use frame_support::weights::Weight;
-use frame_support::{
-    decl_error, decl_event, decl_module, decl_storage, ensure,
-    traits::{Currency, ExistenceRequirement},
-};
-use frame_system::ensure_signed;
-use ternoa_common::traits::{LockableNFTs, NFTs};
-
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
 mod default_weights;
@@ -15,96 +7,123 @@ mod default_weights;
 #[cfg(test)]
 mod tests;
 
+pub use pallet::*;
+
+use frame_support::weights::Weight;
+
 pub trait WeightInfo {
     fn list() -> Weight;
     fn unlist() -> Weight;
     fn buy() -> Weight;
 }
 
-pub trait Config: frame_system::Config {
-    /// Because this pallet emits events, it depends on the runtime's definition of an event.
-    type Event: From<Event<Self>> + Into<<Self as frame_system::Config>::Event>;
-    /// Currency used to handle transactions and pay for the nfts.
-    type Currency: Currency<Self::AccountId>;
-    /// Pallet managing nfts.
-    type NFTs: LockableNFTs<AccountId = Self::AccountId>
-        + NFTs<AccountId = Self::AccountId, NFTId = NFTIdOf<Self>>;
-    /// Weight values for this pallet
-    type WeightInfo: WeightInfo;
-}
+#[frame_support::pallet]
+pub mod pallet {
+    use super::WeightInfo;
 
-type BalanceOf<T> =
-    <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+    use frame_support::pallet_prelude::{
+        ensure, Blake2_128Concat, DispatchResultWithPostInfo, Hooks, IsType, PhantomData,
+        StorageMap, ValueQuery,
+    };
+    use frame_support::traits::{Currency, ExistenceRequirement};
+    use frame_system::pallet_prelude::{ensure_signed, BlockNumberFor, OriginFor};
+    use ternoa_common::traits::{LockableNFTs, NFTs};
 
-type NFTIdOf<T> = <<T as Config>::NFTs as LockableNFTs>::NFTId;
+    type BalanceOf<T> =
+        <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+    type NFTIdOf<T> = <<T as Config>::NFTs as LockableNFTs>::NFTId;
 
-decl_event!(
-    pub enum Event<T>
-    where
-        AccountId = <T as frame_system::Config>::AccountId,
-        Balance = BalanceOf<T>,
-        NFTId = NFTIdOf<T>,
-    {
+    #[pallet::config]
+    pub trait Config: frame_system::Config {
+        /// Because this pallet emits events, it depends on the runtime's definition of an event.
+        type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+        /// Currency used to handle transactions and pay for the nfts.
+        type Currency: Currency<Self::AccountId>;
+        /// Pallet managing nfts.
+        type NFTs: LockableNFTs<AccountId = Self::AccountId>
+            + NFTs<AccountId = Self::AccountId, NFTId = NFTIdOf<Self>>;
+        /// Weight values for this pallet
+        type WeightInfo: WeightInfo;
+    }
+
+    #[pallet::event]
+    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    #[pallet::metadata(T::AccountId = "AccountId", T::NFTId = "NFTId", T::Balance = "Balance")]
+    pub enum Event<T: Config> {
         /// A nft has been listed for sale. \[nft id, price\]
-        NftListed(NFTId, Balance),
+        NftListed(NFTIdOf<T>, BalanceOf<T>),
         /// A nft is removed from the marketplace by its owner. \[nft id\]
-        NftUnlisted(NFTId),
+        NftUnlisted(NFTIdOf<T>),
         /// A nft has been sold. \[nft id, new owner\]
-        NftSold(NFTId, AccountId),
+        NftSold(NFTIdOf<T>, T::AccountId),
     }
-);
 
-decl_storage! {
-    trait Store for Module<T: Config> as Marketplace {
-        /// Nfts listed on the marketplace
-        pub NFTsForSale get(fn nft_for_sale): map hasher(blake2_128_concat) NFTIdOf<T> => (T::AccountId, BalanceOf<T>);
-    }
-}
-
-decl_error! {
-    pub enum Error for Module<T: Config> {
+    #[pallet::error]
+    pub enum Error<T> {
         /// This function is reserved to the owner of a nft.
         NotNftOwner,
         /// Nft is not present on the marketplace
         NftNotForSale,
     }
-}
 
-decl_module! {
-    pub struct Module<T: Config> for enum Call where origin: T::Origin {
-        fn deposit_event() = default;
+    #[pallet::storage]
+    #[pallet::getter(fn nft_for_sale)]
+    pub type NFTsForSale<T: Config> =
+        StorageMap<_, Blake2_128Concat, NFTIdOf<T>, (T::AccountId, BalanceOf<T>), ValueQuery>;
 
-        /// Deposit a nft and list it on the marketplace
-        #[weight = T::WeightInfo::list()]
-        fn list(origin, nft_id: NFTIdOf<T>, price: BalanceOf<T>) {
+    #[pallet::pallet]
+    #[pallet::generate_store(pub(super) trait Store)]
+    pub struct Pallet<T>(PhantomData<T>);
+
+    #[pallet::hooks]
+    impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {
+        #[pallet::weight(T::WeightInfo::list())]
+        pub fn list(
+            origin: OriginFor<T>,
+            nft_id: NFTIdOf<T>,
+            price: BalanceOf<T>,
+        ) -> DispatchResultWithPostInfo {
             let who = ensure_signed(origin)?;
             ensure!(T::NFTs::owner(nft_id) == who, Error::<T>::NotNftOwner);
 
             T::NFTs::lock(nft_id)?;
             NFTsForSale::<T>::insert(nft_id, (who.clone(), price));
 
-            Self::deposit_event(RawEvent::NftListed(nft_id, price));
+            Self::deposit_event(Event::NftListed(nft_id, price));
+
+            Ok(().into())
         }
 
         /// Owner unlist the nfts
-        #[weight = T::WeightInfo::unlist()]
-        fn unlist(origin, nft_id: NFTIdOf<T>) {
+        #[pallet::weight(T::WeightInfo::unlist())]
+        pub fn unlist(origin: OriginFor<T>, nft_id: NFTIdOf<T>) -> DispatchResultWithPostInfo {
             let who = ensure_signed(origin)?;
 
             ensure!(T::NFTs::owner(nft_id) == who, Error::<T>::NotNftOwner);
-            ensure!(NFTsForSale::<T>::contains_key(nft_id), Error::<T>::NftNotForSale);
+            ensure!(
+                NFTsForSale::<T>::contains_key(nft_id),
+                Error::<T>::NftNotForSale
+            );
 
             T::NFTs::unlock(nft_id);
             NFTsForSale::<T>::remove(nft_id);
 
-            Self::deposit_event(RawEvent::NftUnlisted(nft_id));
+            Self::deposit_event(Event::NftUnlisted(nft_id));
+
+            Ok(().into())
         }
 
         /// Buy a listed nft
-        #[weight = T::WeightInfo::buy()]
-        fn buy(origin, nft_id: NFTIdOf<T>) {
+        #[pallet::weight(T::WeightInfo::buy())]
+        pub fn buy(origin: OriginFor<T>, nft_id: NFTIdOf<T>) -> DispatchResultWithPostInfo {
             let who = ensure_signed(origin)?;
-            ensure!(NFTsForSale::<T>::contains_key(nft_id), Error::<T>::NftNotForSale);
+            ensure!(
+                NFTsForSale::<T>::contains_key(nft_id),
+                Error::<T>::NftNotForSale
+            );
 
             let (owner, price) = NFTsForSale::<T>::get(nft_id);
             // KeepAlive because they need to be able to use the NFT later on
@@ -112,7 +131,9 @@ decl_module! {
             T::NFTs::unlock(nft_id);
             T::NFTs::set_owner(nft_id, &who)?;
 
-            Self::deposit_event(RawEvent::NftSold(nft_id, who));
+            Self::deposit_event(Event::NftSold(nft_id, who));
+
+            Ok(().into())
         }
     }
 }

--- a/pallets/marketplace/src/lib.rs
+++ b/pallets/marketplace/src/lib.rs
@@ -44,7 +44,7 @@ pub mod pallet {
 
     #[pallet::event]
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
-    #[pallet::metadata(T::AccountId = "AccountId", T::NFTId = "NFTId", T::Balance = "Balance")]
+    #[pallet::metadata(T::AccountId = "AccountId", NFTIdOf<T> = "NFTId", BalanceOf<T> = "Balance")]
     pub enum Event<T: Config> {
         /// A nft has been listed for sale. \[nft id, price\]
         NftListed(NFTIdOf<T>, BalanceOf<T>),
@@ -62,6 +62,7 @@ pub mod pallet {
         NftNotForSale,
     }
 
+    /// Nfts listed on the marketplace
     #[pallet::storage]
     #[pallet::getter(fn nft_for_sale)]
     pub type NFTsForSale<T: Config> =
@@ -76,6 +77,7 @@ pub mod pallet {
 
     #[pallet::call]
     impl<T: Config> Pallet<T> {
+        /// Deposit a nft and list it on the marketplace
         #[pallet::weight(T::WeightInfo::list())]
         pub fn list(
             origin: OriginFor<T>,

--- a/pallets/marketplace/src/tests/dispatchables.rs
+++ b/pallets/marketplace/src/tests/dispatchables.rs
@@ -1,6 +1,6 @@
 use super::mock::*;
 use crate::{Error, NFTsForSale};
-use frame_support::{assert_noop, assert_ok, StorageMap};
+use frame_support::{assert_noop, assert_ok};
 use frame_system::RawOrigin;
 
 #[test]

--- a/pallets/marketplace/src/tests/mock.rs
+++ b/pallets/marketplace/src/tests/mock.rs
@@ -1,6 +1,7 @@
 use crate::{self as ternoa_marketplace, Config};
 use codec::{Decode, Encode};
 use frame_support::parameter_types;
+use frame_support::traits::GenesisBuild;
 use serde::{Deserialize, Serialize};
 use sp_core::H256;
 use sp_runtime::{

--- a/pallets/nfts/src/lib.rs
+++ b/pallets/nfts/src/lib.rs
@@ -94,10 +94,12 @@ pub mod pallet {
         Locked,
     }
 
+    /// The number of NFTs managed by this pallet
     #[pallet::storage]
     #[pallet::getter(fn total)]
     pub type Total<T: Config> = StorageValue<_, T::NFTId, ValueQuery>;
 
+    /// Data related to NFTs.
     #[pallet::storage]
     #[pallet::getter(fn data)]
     pub type Data<T: Config> =

--- a/pallets/nfts/src/lib.rs
+++ b/pallets/nfts/src/lib.rs
@@ -107,7 +107,6 @@ pub mod pallet {
     pub type Data<T: Config> =
         StorageMap<_, Blake2_128Concat, T::NFTId, NFTData<T::AccountId, T::NFTDetails>, ValueQuery>;
 
-    #[cfg(feature = "std")]
     #[pallet::genesis_config]
     pub struct GenesisConfig<T: Config> {
         pub nfts: Vec<(T::AccountId, T::NFTDetails)>,
@@ -122,7 +121,6 @@ pub mod pallet {
         }
     }
 
-    #[cfg(feature = "std")]
     #[pallet::genesis_build]
     impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
         fn build(&self) {

--- a/pallets/nfts/src/lib.rs
+++ b/pallets/nfts/src/lib.rs
@@ -60,77 +60,6 @@ pub mod pallet {
         type WeightInfo: WeightInfo;
     }
 
-    #[pallet::event]
-    #[pallet::generate_deposit(pub(super) fn deposit_event)]
-    #[pallet::metadata(T::AccountId = "AccountId", T::NFTId = "NFTId")]
-    pub enum Event<T: Config> {
-        /// A new NFT was created. \[nft id, owner\]
-        Created(T::NFTId, T::AccountId),
-        /// An NFT was transferred to someone else. \[nft id, old owner, new owner\]
-        Transfer(T::NFTId, T::AccountId, T::AccountId),
-        /// An NFT was updated by its owner. \[nft id\]
-        Mutated(T::NFTId),
-        /// An NFT was sealed, preventing any new mutations. \[nft id\]
-        Sealed(T::NFTId),
-        /// An NFT has been locked, preventing transfers until it is unlocked.
-        /// \[nft id\]
-        Locked(T::NFTId),
-        /// A locked NFT has been unlocked. \[nft id\]
-        Unlocked(T::NFTId),
-        /// An NFT that was burned. \[nft id\]
-        Burned(T::NFTId),
-    }
-
-    #[pallet::error]
-    pub enum Error<T> {
-        /// We do not have any NFT id left, a runtime upgrade is necessary.
-        NFTIdOverflow,
-        /// This function can only be called by the owner of the nft.
-        NotOwner,
-        /// NFT is sealed and no longer accepts mutations.
-        Sealed,
-        /// NFT is locked and thus its owner cannot be changed until it
-        /// is unlocked.
-        Locked,
-    }
-
-    /// The number of NFTs managed by this pallet
-    #[pallet::storage]
-    #[pallet::getter(fn total)]
-    pub type Total<T: Config> = StorageValue<_, T::NFTId, ValueQuery>;
-
-    /// Data related to NFTs.
-    #[pallet::storage]
-    #[pallet::getter(fn data)]
-    pub type Data<T: Config> =
-        StorageMap<_, Blake2_128Concat, T::NFTId, NFTData<T::AccountId, T::NFTDetails>, ValueQuery>;
-
-    #[pallet::genesis_config]
-    pub struct GenesisConfig<T: Config> {
-        pub nfts: Vec<(T::AccountId, T::NFTDetails)>,
-    }
-
-    #[cfg(feature = "std")]
-    impl<T: Config> Default for GenesisConfig<T> {
-        fn default() -> Self {
-            Self {
-                nfts: Default::default(),
-            }
-        }
-    }
-
-    #[pallet::genesis_build]
-    impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
-        fn build(&self) {
-            self.nfts
-                .clone()
-                .into_iter()
-                .for_each(|(account, details)| {
-                    drop(<Pallet<T> as NFTs>::create(&account, details))
-                });
-        }
-    }
-
     #[pallet::pallet]
     #[pallet::generate_store(pub(super) trait Store)]
     pub struct Pallet<T>(PhantomData<T>);
@@ -225,6 +154,77 @@ pub mod pallet {
             <Self as NFTs>::burn(id).expect("Call to Burn function should never fail!");
 
             Ok(().into())
+        }
+    }
+
+    #[pallet::event]
+    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    #[pallet::metadata(T::AccountId = "AccountId", T::NFTId = "NFTId")]
+    pub enum Event<T: Config> {
+        /// A new NFT was created. \[nft id, owner\]
+        Created(T::NFTId, T::AccountId),
+        /// An NFT was transferred to someone else. \[nft id, old owner, new owner\]
+        Transfer(T::NFTId, T::AccountId, T::AccountId),
+        /// An NFT was updated by its owner. \[nft id\]
+        Mutated(T::NFTId),
+        /// An NFT was sealed, preventing any new mutations. \[nft id\]
+        Sealed(T::NFTId),
+        /// An NFT has been locked, preventing transfers until it is unlocked.
+        /// \[nft id\]
+        Locked(T::NFTId),
+        /// A locked NFT has been unlocked. \[nft id\]
+        Unlocked(T::NFTId),
+        /// An NFT that was burned. \[nft id\]
+        Burned(T::NFTId),
+    }
+
+    #[pallet::error]
+    pub enum Error<T> {
+        /// We do not have any NFT id left, a runtime upgrade is necessary.
+        NFTIdOverflow,
+        /// This function can only be called by the owner of the nft.
+        NotOwner,
+        /// NFT is sealed and no longer accepts mutations.
+        Sealed,
+        /// NFT is locked and thus its owner cannot be changed until it
+        /// is unlocked.
+        Locked,
+    }
+
+    /// The number of NFTs managed by this pallet
+    #[pallet::storage]
+    #[pallet::getter(fn total)]
+    pub type Total<T: Config> = StorageValue<_, T::NFTId, ValueQuery>;
+
+    /// Data related to NFTs.
+    #[pallet::storage]
+    #[pallet::getter(fn data)]
+    pub type Data<T: Config> =
+        StorageMap<_, Blake2_128Concat, T::NFTId, NFTData<T::AccountId, T::NFTDetails>, ValueQuery>;
+
+    #[pallet::genesis_config]
+    pub struct GenesisConfig<T: Config> {
+        pub nfts: Vec<(T::AccountId, T::NFTDetails)>,
+    }
+
+    #[cfg(feature = "std")]
+    impl<T: Config> Default for GenesisConfig<T> {
+        fn default() -> Self {
+            Self {
+                nfts: Default::default(),
+            }
+        }
+    }
+
+    #[pallet::genesis_build]
+    impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
+        fn build(&self) {
+            self.nfts
+                .clone()
+                .into_iter()
+                .for_each(|(account, details)| {
+                    drop(<Pallet<T> as NFTs>::create(&account, details))
+                });
         }
     }
 }

--- a/pallets/nfts/src/lib.rs
+++ b/pallets/nfts/src/lib.rs
@@ -41,16 +41,9 @@ pub trait WeightInfo {
 
 #[frame_support::pallet]
 pub mod pallet {
-    #[cfg(feature = "std")]
-    use frame_support::traits::GenesisBuild;
-
-    use super::{NFTData, WeightInfo};
-    use frame_support::pallet_prelude::{
-        ensure, Blake2_128Concat, DispatchResultWithPostInfo, Hooks, IsType,
-        MaybeSerializeDeserialize, Member, Parameter, PhantomData, StorageMap, StorageValue,
-        ValueQuery,
-    };
-    use frame_system::pallet_prelude::{ensure_signed, BlockNumberFor, OriginFor};
+    use super::*;
+    use frame_support::pallet_prelude::*;
+    use frame_system::pallet_prelude::*;
     use sp_runtime::traits::{CheckedAdd, StaticLookup};
     use sp_runtime::DispatchResult;
     use ternoa_common::traits::NFTs;

--- a/pallets/nfts/src/tests/genesis.rs
+++ b/pallets/nfts/src/tests/genesis.rs
@@ -1,4 +1,6 @@
 use super::mock::*;
+use crate::GenesisConfig;
+use frame_support::traits::GenesisBuild;
 
 #[test]
 fn register_nfts() {
@@ -6,7 +8,7 @@ fn register_nfts() {
         .build_storage::<Test>()
         .unwrap();
 
-    crate::GenesisConfig::<Test> {
+    GenesisConfig::<Test> {
         nfts: vec![(ALICE, MockNFTDetails::WithU8(1))],
     }
     .assimilate_storage(&mut t)

--- a/pallets/nfts/src/tests/spec.rs
+++ b/pallets/nfts/src/tests/spec.rs
@@ -1,6 +1,6 @@
 use super::mock::*;
 use crate::{Data, Error, NFTData};
-use frame_support::{assert_noop, assert_ok, StorageMap};
+use frame_support::{assert_noop, assert_ok};
 use frame_system::RawOrigin;
 
 #[test]

--- a/pallets/timed-escrow/src/lib.rs
+++ b/pallets/timed-escrow/src/lib.rs
@@ -50,30 +50,6 @@ pub mod pallet {
         type WeightInfo: WeightInfo;
     }
 
-    #[pallet::event]
-    #[pallet::generate_deposit(pub(super) fn deposit_event)]
-    #[pallet::metadata(
-        T::AccountId = "AccountId",
-        T::BlockNumber = "BlockNumber",
-        NFTIdOf<T> = "NFTId"
-    )]
-    pub enum Event<T: Config> {
-        /// A transfer has been scheduled. \[capsule id, destination, block of transfer\]
-        TransferScheduled(NFTIdOf<T>, T::AccountId, T::BlockNumber),
-        /// A transfer has been canceled. \[capsule id\]
-        TransferCanceled(NFTIdOf<T>),
-        /// A transfer was executed and finalized. \[capsule id\]
-        TransferCompleted(NFTIdOf<T>),
-    }
-
-    #[pallet::error]
-    pub enum Error<T> {
-        /// This function is reserved to the owner of a nft.
-        NotNFTOwner,
-        /// An unknown error happened which made the scheduling call fail.
-        SchedulingFailed,
-    }
-
     #[pallet::pallet]
     pub struct Pallet<T>(PhantomData<T>);
 
@@ -153,5 +129,29 @@ pub mod pallet {
 
             Ok(().into())
         }
+    }
+
+    #[pallet::event]
+    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    #[pallet::metadata(
+        T::AccountId = "AccountId",
+        T::BlockNumber = "BlockNumber",
+        NFTIdOf<T> = "NFTId"
+    )]
+    pub enum Event<T: Config> {
+        /// A transfer has been scheduled. \[capsule id, destination, block of transfer\]
+        TransferScheduled(NFTIdOf<T>, T::AccountId, T::BlockNumber),
+        /// A transfer has been canceled. \[capsule id\]
+        TransferCanceled(NFTIdOf<T>),
+        /// A transfer was executed and finalized. \[capsule id\]
+        TransferCompleted(NFTIdOf<T>),
+    }
+
+    #[pallet::error]
+    pub enum Error<T> {
+        /// This function is reserved to the owner of a nft.
+        NotNFTOwner,
+        /// An unknown error happened which made the scheduling call fail.
+        SchedulingFailed,
     }
 }

--- a/pallets/timed-escrow/src/lib.rs
+++ b/pallets/timed-escrow/src/lib.rs
@@ -1,23 +1,15 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::Encode;
-use frame_support::{
-    decl_error, decl_event, decl_module, ensure,
-    traits::{
-        schedule::{DispatchTime, Named as ScheduleNamed},
-        LockIdentifier,
-    },
-    weights::Weight,
-};
-use frame_system::{ensure_root, ensure_signed, RawOrigin};
-use sp_runtime::{traits::Dispatchable, traits::StaticLookup};
-use ternoa_common::traits::{LockableNFTs, NFTs};
-
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
 mod default_weights;
 #[cfg(test)]
 mod tests;
+
+pub use pallet::*;
+
+use frame_support::traits::LockIdentifier;
+use frame_support::weights::Weight;
 
 /// Used for derivating scheduled tasks IDs
 const ESCROW_ID: LockIdentifier = *b"escrow  ";
@@ -28,93 +20,127 @@ pub trait WeightInfo {
     fn complete_transfer() -> Weight;
 }
 
-pub trait Config: frame_system::Config {
-    /// Because this pallet emits events, it depends on the runtime's definition of an event.
-    type Event: From<Event<Self>> + Into<<Self as frame_system::Config>::Event>;
-    /// Pallet managing NFTs.
-    type NFTs: LockableNFTs<AccountId = Self::AccountId>
-        + NFTs<AccountId = Self::AccountId, NFTId = NFTIdOf<Self>>;
-    /// Scheduler instance which we use to schedule actual transfer calls. This way, we have
-    /// all scheduled calls accross all pallets in one place.
-    type Scheduler: ScheduleNamed<Self::BlockNumber, Self::PalletsCall, Self::PalletsOrigin>;
-    /// Overarching type of all pallets origins. Used with the scheduler.
-    type PalletsOrigin: From<RawOrigin<Self::AccountId>>;
-    /// Overarching type of all pallets calls. Used by the scheduler.
-    type PalletsCall: Dispatchable<Origin = Self::Origin> + From<Call<Self>>;
-    /// Weight values for this pallet
-    type WeightInfo: WeightInfo;
-}
+#[frame_support::pallet]
+pub mod pallet {
+    use super::*;
+    use frame_support::pallet_prelude::*;
+    use frame_support::traits::schedule::{DispatchTime, Named as ScheduleNamed};
+    use frame_system::pallet_prelude::*;
+    use frame_system::RawOrigin;
+    use sp_runtime::traits::{Dispatchable, StaticLookup};
+    use ternoa_common::traits::{LockableNFTs, NFTs};
 
-type NFTIdOf<T> = <<T as Config>::NFTs as LockableNFTs>::NFTId;
+    pub type NFTIdOf<T> = <<T as Config>::NFTs as LockableNFTs>::NFTId;
 
-decl_event!(
-    pub enum Event<T>
-    where
-        AccountId = <T as frame_system::Config>::AccountId,
-        NFTId = NFTIdOf<T>,
-        BlockNumber = <T as frame_system::Config>::BlockNumber,
-    {
-        /// A transfer has been scheduled. \[capsule id, destination, block of transfer\]
-        TransferScheduled(NFTId, AccountId, BlockNumber),
-        /// A transfer has been canceled. \[capsule id\]
-        TransferCanceled(NFTId),
-        /// A transfer was executed and finalized. \[capsule id\]
-        TransferCompleted(NFTId),
+    #[pallet::config]
+    pub trait Config: frame_system::Config {
+        /// Because this pallet emits events, it depends on the runtime's definition of an event.
+        type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+        /// Pallet managing NFTs.
+        type NFTs: LockableNFTs<AccountId = Self::AccountId>
+            + NFTs<AccountId = Self::AccountId, NFTId = NFTIdOf<Self>>;
+        /// Scheduler instance which we use to schedule actual transfer calls. This way, we have
+        /// all scheduled calls accross all pallets in one place.
+        type Scheduler: ScheduleNamed<Self::BlockNumber, Self::PalletsCall, Self::PalletsOrigin>;
+        /// Overarching type of all pallets origins. Used with the scheduler.
+        type PalletsOrigin: From<RawOrigin<Self::AccountId>>;
+        /// Overarching type of all pallets calls. Used by the scheduler.
+        type PalletsCall: Dispatchable<Origin = Self::Origin> + From<Call<Self>>;
+        /// Weight values for this pallet
+        type WeightInfo: WeightInfo;
     }
-);
 
-decl_error! {
-    pub enum Error for Module<T: Config> {
+    #[pallet::event]
+    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    #[pallet::metadata(
+        T::AccountId = "AccountId",
+        T::BlockNumber = "BlockNumber",
+        NFTIdOf<T> = "NFTId"
+    )]
+    pub enum Event<T: Config> {
+        /// A transfer has been scheduled. \[capsule id, destination, block of transfer\]
+        TransferScheduled(NFTIdOf<T>, T::AccountId, T::BlockNumber),
+        /// A transfer has been canceled. \[capsule id\]
+        TransferCanceled(NFTIdOf<T>),
+        /// A transfer was executed and finalized. \[capsule id\]
+        TransferCompleted(NFTIdOf<T>),
+    }
+
+    #[pallet::error]
+    pub enum Error<T> {
         /// This function is reserved to the owner of a nft.
         NotNFTOwner,
         /// An unknown error happened which made the scheduling call fail.
         SchedulingFailed,
     }
-}
 
-decl_module! {
-    pub struct Module<T: Config> for enum Call where origin: T::Origin {
-        fn deposit_event() = default;
+    #[pallet::pallet]
+    pub struct Pallet<T>(PhantomData<T>);
 
+    #[pallet::hooks]
+    impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {
         /// Create a timed transfer. This will lock the associated capsule until it gets
         /// transferred or canceled.
-        #[weight = T::WeightInfo::create()]
-        fn create(origin, nft_id: NFTIdOf<T>, to: <T::Lookup as StaticLookup>::Source, at: T::BlockNumber) {
+        #[pallet::weight(T::WeightInfo::create())]
+        pub fn create(
+            origin: OriginFor<T>,
+            nft_id: NFTIdOf<T>,
+            to: <T::Lookup as StaticLookup>::Source,
+            at: T::BlockNumber,
+        ) -> DispatchResultWithPostInfo {
             let who = ensure_signed(origin)?;
             ensure!(T::NFTs::owner(nft_id) == who, Error::<T>::NotNFTOwner);
 
             let to_unlookup = T::Lookup::lookup(to)?;
             T::NFTs::lock(nft_id)?;
 
-            ensure!(T::Scheduler::schedule_named(
-                (ESCROW_ID, nft_id).encode(),
-                DispatchTime::At(at),
-                None,
-                // priority was chosen arbitrarily, we made sure it is lower than runtime
-                // upgrades and democracy calls
-                100,
-                RawOrigin::Root.into(),
-                Call::complete_transfer(to_unlookup.clone(), nft_id).into()
-            ).is_ok(), Error::<T>::SchedulingFailed);
+            ensure!(
+                T::Scheduler::schedule_named(
+                    (ESCROW_ID, nft_id).encode(),
+                    DispatchTime::At(at),
+                    None,
+                    // priority was chosen arbitrarily, we made sure it is lower than runtime
+                    // upgrades and democracy calls
+                    100,
+                    RawOrigin::Root.into(),
+                    Call::complete_transfer(to_unlookup.clone(), nft_id).into()
+                )
+                .is_ok(),
+                Error::<T>::SchedulingFailed
+            );
 
-            Self::deposit_event(RawEvent::TransferScheduled(nft_id, to_unlookup, at));
+            Self::deposit_event(Event::TransferScheduled(nft_id, to_unlookup, at));
+
+            Ok(().into())
         }
 
         /// Cancel a transfer that was previously created and unlocks the capsule.
-        #[weight = T::WeightInfo::cancel()]
-        fn cancel(origin, nft_id: NFTIdOf<T>) {
+        #[pallet::weight(T::WeightInfo::cancel())]
+        pub fn cancel(origin: OriginFor<T>, nft_id: NFTIdOf<T>) -> DispatchResultWithPostInfo {
             let who = ensure_signed(origin)?;
             ensure!(T::NFTs::owner(nft_id) == who, Error::<T>::NotNFTOwner);
 
-            ensure!(T::Scheduler::cancel_named((ESCROW_ID, nft_id).encode()).is_ok(), Error::<T>::SchedulingFailed);
+            ensure!(
+                T::Scheduler::cancel_named((ESCROW_ID, nft_id).encode()).is_ok(),
+                Error::<T>::SchedulingFailed
+            );
             T::NFTs::unlock(nft_id);
 
-            Self::deposit_event(RawEvent::TransferCanceled(nft_id));
+            Self::deposit_event(Event::TransferCanceled(nft_id));
+
+            Ok(().into())
         }
 
         /// System only. Execute a transfer, called by the scheduler.
-        #[weight = T::WeightInfo::complete_transfer()]
-        fn complete_transfer(origin, to: T::AccountId, nft_id: NFTIdOf<T>) {
+        #[pallet::weight(T::WeightInfo::complete_transfer())]
+        pub fn complete_transfer(
+            origin: OriginFor<T>,
+            to: T::AccountId,
+            nft_id: NFTIdOf<T>,
+        ) -> DispatchResultWithPostInfo {
             // We do not verify anything else as the only way for this function
             // to be called is if it was scheduled via either root action (trusted)
             // or the call to `create` which will verify NFT ownership and locking
@@ -123,7 +149,9 @@ decl_module! {
             T::NFTs::unlock(nft_id);
             T::NFTs::set_owner(nft_id, &to)?;
 
-            Self::deposit_event(RawEvent::TransferCompleted(nft_id));
+            Self::deposit_event(Event::TransferCompleted(nft_id));
+
+            Ok(().into())
         }
     }
 }


### PR DESCRIPTION
I followed the official upgrade [guidelines](https://crates.parity.io/frame_support/attr.pallet.html#upgrade-guidelines) from Parity in order to ensure that the transition doesn't break anything.

One of the upgrade checks is to check if the generated metadata does not differ from the original one (main branch). For most part of it it doesn't but there is one line that differs and I am not sure if that's OK.

![image](https://user-images.githubusercontent.com/4882434/115387239-aea62a80-a1da-11eb-8373-18346630bc58.png)

The storage prefix changed from `NFTs` to `Nfts`. There is a sentence about a change like that in the offical upgrade guidelines but I not sure if I am interpreting it right. 

![image](https://user-images.githubusercontent.com/4882434/115387532-22e0ce00-a1db-11eb-8347-72c31d2f24b2.png)

Metadata from the main branch: [Data](https://gist.github.com/markopoloparadox/5693baff270148e44ca43964a2fa86f7)
Metadata from this PR: [Data](https://gist.github.com/markopoloparadox/5b77693ad81793fc018874a42888df11)

I did some manual testing and it looks like everything is working OK.
