### PR TITLE
Marko/qty function for nft on market place

### DIFF
--- a/common/src/nfts.rs
+++ b/common/src/nfts.rs
@@ -20,6 +20,13 @@ pub trait NFTs {
         details: Self::NFTDetails,
     ) -> result::Result<Self::NFTId, DispatchError>;
 
+    /// TODO!
+    fn create_series(
+        owner: &Self::AccountId,
+        details: Self::NFTDetails,
+        quantity: u128,
+    ) -> result::Result<sp_std::vec::Vec<Self::NFTId>, DispatchError>;
+
     /// Change the details related to an NFT.
     fn mutate<F: FnOnce(&Self::AccountId, &mut Self::NFTDetails) -> DispatchResult>(
         id: Self::NFTId,
@@ -43,6 +50,12 @@ pub trait NFTs {
 
     /// Remove an NFT from the storage.
     fn burn(id: Self::NFTId) -> DispatchResult;
+
+    /// TODO!
+    fn series_id(id: Self::NFTId) -> u128;
+
+    /// TODO!
+    fn item_id(id: Self::NFTId) -> u128;
 }
 
 /// Implemented by a pallet where it is possible to lock NFTs.

--- a/pallets/nfts/src/lib.rs
+++ b/pallets/nfts/src/lib.rs
@@ -20,6 +20,9 @@ mod default_weights;
 #[cfg(test)]
 mod tests;
 
+pub type SeriesId = u128;
+pub type ItemId = u128;
+
 /// Data related to an NFT, such as who is its owner.
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
@@ -31,9 +34,9 @@ pub struct NFTData<AccountId, NFTDetails> {
     /// Set to true to prevent changes to the owner variable
     pub locked: bool,
     /// TODO!
-    pub series_id: u128,
+    pub series_id: SeriesId,
     /// TODO!
-    pub item_id: u128,
+    pub item_id: ItemId,
 }
 
 pub trait WeightInfo {
@@ -62,9 +65,9 @@ decl_storage! {
         /// Data related to NFTs.
         pub Data get(fn data): map hasher(blake2_128_concat) T::NFTId => NFTData<T::AccountId, T::NFTDetails>;
         /// TODO!
-        pub TotalSeries get(fn total_series): u128;
+        pub TotalSeries get(fn total_series): SeriesId;
         /// TODO!
-        pub Series get(fn series): map hasher(blake2_128_concat) u128 => sp_std::vec::Vec<T::NFTId>;
+        pub Series get(fn series): map hasher(blake2_128_concat) SeriesId => sp_std::vec::Vec<T::NFTId>;
     }
     add_extra_genesis {
         config(nfts): Vec<(T::AccountId, T::NFTDetails)>;
@@ -100,7 +103,7 @@ decl_event!(
         /// An NFT that was burned. \[nft id\]
         Burned(NFTId),
         /// A new NFT series was created. \[series id, owner, count\]
-        SeriesCreated(u128, AccountId, u128),
+        SeriesCreated(SeriesId, AccountId, u128),
     }
 );
 
@@ -285,11 +288,11 @@ impl<T: Config> NFTs for Module<T> {
         Ok(())
     }
 
-    fn series_id(id: Self::NFTId) -> u128 {
+    fn series_id(id: Self::NFTId) -> SeriesId {
         Data::<T>::get(id).series_id
     }
 
-    fn item_id(id: Self::NFTId) -> u128 {
+    fn item_id(id: Self::NFTId) -> ItemId {
         Data::<T>::get(id).item_id
     }
 


### PR DESCRIPTION
@ybensacq @ETeissonniere 

This is just a draft so that I can get feedback as soon as possible.
The goal is to implement the necessary infrastructure to support multiple copies of the same nft. 

In order to support multiple nfts that are part of a series,  NFTData structure was expanded and now includes series_id and item_id. Two new storage units were created, one for mapping a series id to the corresponding created nfts and one which counts how many series id were created. Also, a new extrinsic was created(`create_series`) in order to test if everything works. 

I know that the names are not the best, that the documentation is missing and that I didn't cover all cases but that is ok because I just want to know if the direction that I am going is valid. 