### PR TITLE
add github action to publish docker image tag chaos on new tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Docker
+name: Docker-chaos-tag
 
 on:
   push:

--- a/.github/workflows/promote_chaos.yml
+++ b/.github/workflows/promote_chaos.yml
@@ -1,0 +1,22 @@
+name: Docker
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  promote-chaos:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Push with chaos tag
+        run: |
+          docker pull ternoa/ternoa-chain:latest
+          docker tag ternoa/ternoa-chain:latest ternoa/ternoa-chain:chaos
+          docker push ternoa/ternoa-chain:chaos


### PR DESCRIPTION
This has been verified to correctly trigger a promotion of the docker image from `ternoa/ternoa-chain:latest` to `ternoa/ternoa-chain:chaos` on new git tags.