### PR TITLE
Marko/move series id into nftdetails

### DIFF
--- a/common/src/nfts.rs
+++ b/common/src/nfts.rs
@@ -21,7 +21,6 @@ pub trait NFTs {
     fn create(
         owner: &Self::AccountId,
         details: Self::NFTDetails,
-        series_id: Self::NFTSeriesId,
     ) -> result::Result<Self::NFTId, DispatchError>;
 
     /// Change the details related to an NFT.

--- a/pallets/marketplace/src/benchmarking.rs
+++ b/pallets/marketplace/src/benchmarking.rs
@@ -9,7 +9,6 @@ fn create_nft<T: Config>(caller: &T::AccountId) -> NFTIdOf<T> {
     T::NFTs::create(
         caller,
         <<T::NFTs as NFTs>::NFTDetails as Default>::default(),
-        Default::default(),
     )
     .expect("shall not fail with a clean state")
 }

--- a/pallets/marketplace/src/tests/mock.rs
+++ b/pallets/marketplace/src/tests/mock.rs
@@ -1,13 +1,12 @@
 use crate::{self as ternoa_marketplace, Config};
-use codec::{Decode, Encode};
 use frame_support::parameter_types;
 use frame_support::traits::GenesisBuild;
-use serde::{Deserialize, Serialize};
 use sp_core::H256;
 use sp_runtime::{
     testing::Header,
     traits::{BlakeTwo256, IdentityLookup},
 };
+use ternoa_nfts::NFTDetails;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -73,9 +72,7 @@ impl pallet_balances::Config for Test {
 impl ternoa_nfts::Config for Test {
     type Event = Event;
     type NFTId = u8;
-    type NFTDetails = MockNFTDetails;
     type WeightInfo = ();
-    type NFTSeriesId = u32;
 }
 
 impl Config for Test {
@@ -84,17 +81,6 @@ impl Config for Test {
     type NFTs = NFTs;
     type WeightInfo = ();
 }
-#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub enum MockNFTDetails {
-    Empty,
-    WithU8(u8),
-}
-impl Default for MockNFTDetails {
-    fn default() -> Self {
-        Self::Empty
-    }
-}
 
 // Do not use the `0` account id since this would be the default value
 // for our account id. This would mess with some tests.
@@ -102,7 +88,7 @@ pub const ALICE: u64 = 1;
 pub const BOB: u64 = 2;
 
 pub struct ExtBuilder {
-    nfts: Vec<(u64, MockNFTDetails, u32)>,
+    nfts: Vec<(u64, NFTDetails)>,
     series: Vec<(u64, u32)>,
     endowed_accounts: Vec<(u64, u64)>,
 }
@@ -119,8 +105,7 @@ impl Default for ExtBuilder {
 
 impl ExtBuilder {
     pub fn one_nft_for_alice(mut self) -> Self {
-        self.nfts
-            .push((ALICE, Default::default(), Default::default()));
+        self.nfts.push((ALICE, NFTDetails::default()));
         self
     }
 

--- a/pallets/nfts/src/benchmarking.rs
+++ b/pallets/nfts/src/benchmarking.rs
@@ -1,4 +1,4 @@
-use crate::{Call, Config, Module, NFTData, NFTSeriesDetails};
+use crate::{Call, Config, Module, NFTData, NFTDetails, NFTSeriesDetails, NFTSeriesId};
 use frame_benchmarking::{account, benchmarks, whitelisted_caller};
 use frame_system::RawOrigin;
 use sp_runtime::traits::StaticLookup;
@@ -7,7 +7,7 @@ use sp_std::{boxed::Box, prelude::*};
 benchmarks! {
     create {
         let caller: T::AccountId = whitelisted_caller();
-    }: _(RawOrigin::Signed(caller.clone()), Default::default(), Default::default())
+    }: _(RawOrigin::Signed(caller.clone()), NFTDetails::default())
     verify {
         let series = NFTSeriesDetails::new(caller, sp_std::vec![T::NFTId::from(0)]);
         assert_eq!(Module::<T>::total(), T::NFTId::from(1));
@@ -15,8 +15,9 @@ benchmarks! {
 
     create_with_series {
         let caller: T::AccountId = whitelisted_caller();
-        let series_id = T::NFTSeriesId::from(1u32);
-    }: create(RawOrigin::Signed(caller.clone()), Default::default(), series_id)
+        let series_id = NFTSeriesId::from(1u32);
+        let details = NFTDetails::new(vec![], series_id);
+    }: create(RawOrigin::Signed(caller.clone()), details)
     verify {
         let series = NFTSeriesDetails::new(caller, sp_std::vec![T::NFTId::from(0)]);
         assert_eq!(Module::<T>::total(), T::NFTId::from(1));
@@ -30,7 +31,7 @@ benchmarks! {
         // than before so calling mutate with the same values (default) will
         // always do the same work and thus keep the benchmark relevant.
 
-        drop(Module::<T>::create(RawOrigin::Signed(caller.clone()).into(), Default::default(), Default::default()));
+        drop(Module::<T>::create(RawOrigin::Signed(caller.clone()).into(), NFTDetails::default()));
     }: _(RawOrigin::Signed(caller), T::NFTId::from(0), Default::default())
     verify {
         // Absence of error should be enough but we also check the
@@ -40,7 +41,7 @@ benchmarks! {
 
     seal {
         let caller: T::AccountId = whitelisted_caller();
-        drop(Module::<T>::create(RawOrigin::Signed(caller.clone()).into(), Default::default(), Default::default()));
+        drop(Module::<T>::create(RawOrigin::Signed(caller.clone()).into(), NFTDetails::default()));
     }: _(RawOrigin::Signed(caller), T::NFTId::from(0))
     verify {
         assert_eq!(Module::<T>::data(T::NFTId::from(0)).sealed, true);
@@ -51,7 +52,7 @@ benchmarks! {
         let receiver_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(receiver.clone());
 
         let caller: T::AccountId = whitelisted_caller();
-        drop(Module::<T>::create(RawOrigin::Signed(caller.clone()).into(), Default::default(), Default::default()));
+        drop(Module::<T>::create(RawOrigin::Signed(caller.clone()).into(), NFTDetails::default()));
     }: _(RawOrigin::Signed(caller), T::NFTId::from(0), receiver_lookup)
     verify {
         assert_eq!(Module::<T>::data(T::NFTId::from(0)).owner, receiver);
@@ -59,9 +60,10 @@ benchmarks! {
 
     burn {
         let caller: T::AccountId = whitelisted_caller();
-        let series_id =  T::NFTSeriesId::from(1);
+        let series_id = NFTSeriesId::from(1u32);
+        let details = NFTDetails::new(vec![], series_id);
         let nft_id = T::NFTId::from(0);
-        drop(Module::<T>::create(RawOrigin::Signed(caller.clone()).into(), Default::default(), series_id));
+        drop(Module::<T>::create(RawOrigin::Signed(caller.clone()).into(), details));
     }: _(RawOrigin::Signed(caller), nft_id)
     verify {
         assert_eq!(Module::<T>::data(nft_id), NFTData::default());
@@ -73,8 +75,9 @@ benchmarks! {
 
 
         let caller: T::AccountId = whitelisted_caller();
-        let series_id = T::NFTSeriesId::from(1);
-        drop(Module::<T>::create(RawOrigin::Signed(caller.clone()).into(), Default::default(),series_id));
+        let series_id = NFTSeriesId::from(1u32);
+        let details = NFTDetails::new(vec![], series_id);
+        drop(Module::<T>::create(RawOrigin::Signed(caller.clone()).into(), details));
     }: _(RawOrigin::Signed(caller), series_id, receiver_lookup)
     verify {
         let series = NFTSeriesDetails::new(receiver, sp_std::vec![T::NFTId::from(0)]);

--- a/pallets/nfts/src/lib.rs
+++ b/pallets/nfts/src/lib.rs
@@ -208,8 +208,8 @@ pub mod pallet {
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
     #[pallet::metadata(T::AccountId = "AccountId", T::NFTId = "NFTId")]
     pub enum Event<T: Config> {
-        /// A new NFT was created. \[nft id, owner\]
-        Created(T::NFTId, T::AccountId),
+        /// A new NFT was created. \[nft id, owner, series id\]
+        Created(T::NFTId, T::AccountId, NFTSeriesId),
         /// An NFT was transferred to someone else. \[nft id, old owner, new owner\]
         Transfer(T::NFTId, T::AccountId, T::AccountId),
         /// An NFT was updated by its owner. \[nft id\]
@@ -355,7 +355,7 @@ impl<T: Config> NFTs for Pallet<T> {
             },
         );
 
-        Self::deposit_event(Event::Created(nft_id, owner.clone()));
+        Self::deposit_event(Event::Created(nft_id, owner.clone(), series_id));
 
         Ok(nft_id)
     }

--- a/pallets/nfts/src/lib.rs
+++ b/pallets/nfts/src/lib.rs
@@ -25,15 +25,13 @@ use ternoa_common::traits::{LockableNFTs, NFTs};
 /// Data related to an NFT, such as who is its owner.
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct NFTData<AccountId, NFTDetails, NFTSeriesId> {
+pub struct NFTData<AccountId, NFTDetails> {
     pub owner: AccountId,
     pub details: NFTDetails,
     /// Set to true to prevent further modifications to the details struct
     pub sealed: bool,
     /// Set to true to prevent changes to the owner variable
     pub locked: bool,
-    /// The Id of the Series that this NFT belongs. Zero means that it doesn't belong to any series.
-    pub series_id: NFTSeriesId,
 }
 
 /// Data related to an NFT Series.
@@ -254,13 +252,8 @@ pub mod pallet {
     /// Data related to NFTs.
     #[pallet::storage]
     #[pallet::getter(fn data)]
-    pub type Data<T: Config> = StorageMap<
-        _,
-        Blake2_128Concat,
-        T::NFTId,
-        NFTData<T::AccountId, NFTDetails, NFTSeriesId>,
-        ValueQuery,
-    >;
+    pub type Data<T: Config> =
+        StorageMap<_, Blake2_128Concat, T::NFTId, NFTData<T::AccountId, NFTDetails>, ValueQuery>;
 
     /// Data related to NFT Series.
     #[pallet::storage]
@@ -351,7 +344,6 @@ impl<T: Config> NFTs for Pallet<T> {
                 details,
                 sealed: false,
                 locked: false,
-                series_id,
             },
         );
 
@@ -424,7 +416,7 @@ impl<T: Config> NFTs for Pallet<T> {
 
     fn series_id(id: Self::NFTId) -> Option<Self::NFTSeriesId> {
         if Data::<T>::contains_key(id) {
-            Some(Data::<T>::get(id).series_id)
+            Some(Data::<T>::get(id).details.series_id)
         } else {
             None
         }

--- a/pallets/nfts/src/tests/genesis.rs
+++ b/pallets/nfts/src/tests/genesis.rs
@@ -1,4 +1,5 @@
 use super::mock::*;
+use crate::types::NFTDetails;
 use crate::GenesisConfig;
 use frame_support::traits::GenesisBuild;
 
@@ -9,7 +10,7 @@ fn register_nfts() {
         .unwrap();
 
     GenesisConfig::<Test> {
-        nfts: vec![(ALICE, MockNFTDetails::WithU8(1), Default::default())],
+        nfts: vec![(ALICE, NFTDetails::new(vec![1], 0))],
         series: vec![],
     }
     .assimilate_storage(&mut t)
@@ -19,7 +20,7 @@ fn register_nfts() {
     ext.execute_with(|| {
         assert_eq!(NFTs::total(), 1);
         assert_eq!(NFTs::data(0).owner, ALICE);
-        assert_eq!(NFTs::data(0).details, MockNFTDetails::WithU8(1));
+        assert_eq!(NFTs::data(0).details, NFTDetails::new(vec![1], 0));
         assert_eq!(NFTs::data(0).locked, false);
         assert_eq!(NFTs::data(0).sealed, false);
     });

--- a/pallets/nfts/src/tests/mock.rs
+++ b/pallets/nfts/src/tests/mock.rs
@@ -1,7 +1,5 @@
 use crate::{self as ternoa_nfts, Config};
-use codec::{Decode, Encode};
 use frame_support::parameter_types;
-use serde::{Deserialize, Serialize};
 use sp_core::H256;
 use sp_runtime::{
     testing::Header,
@@ -52,17 +50,6 @@ impl frame_system::Config for Test {
     type SS58Prefix = ();
 }
 
-#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub enum MockNFTDetails {
-    Empty,
-    WithU8(u8),
-}
-impl Default for MockNFTDetails {
-    fn default() -> Self {
-        Self::Empty
-    }
-}
 impl Config for Test {
     type Event = Event;
     type NFTId = u32;

--- a/pallets/nfts/src/tests/mock.rs
+++ b/pallets/nfts/src/tests/mock.rs
@@ -66,9 +66,7 @@ impl Default for MockNFTDetails {
 impl Config for Test {
     type Event = Event;
     type NFTId = u32;
-    type NFTDetails = MockNFTDetails;
     type WeightInfo = ();
-    type NFTSeriesId = u32;
 }
 
 // Do not use the `0` account id since this would be the default value

--- a/pallets/nfts/src/tests/spec.rs
+++ b/pallets/nfts/src/tests/spec.rs
@@ -18,7 +18,7 @@ fn create_increment_id() {
 #[test]
 fn create_register_details() {
     new_test_ext().execute_with(|| {
-        let details = NFTDetails::new(vec![0, 1], 1);
+        let details = NFTDetails::new(vec![42], 1);
 
         assert_ok!(NFTs::create(
             RawOrigin::Signed(ALICE).into(),
@@ -53,7 +53,7 @@ fn create_is_unsealed() {
 #[test]
 fn mutate_update_details() {
     new_test_ext().execute_with(|| {
-        let details = NFTDetails::new(vec![0, 1], 1);
+        let details = NFTDetails::new(vec![42], 1);
         let nft_id = 0;
 
         assert_ok!(NFTs::create(
@@ -72,7 +72,7 @@ fn mutate_update_details() {
 #[test]
 fn mutate_not_the_owner() {
     new_test_ext().execute_with(|| {
-        let details = NFTDetails::new(vec![0, 1], 1);
+        let details = NFTDetails::new(vec![42], 1);
         let nft_id = 0;
 
         assert_ok!(NFTs::create(
@@ -89,7 +89,7 @@ fn mutate_not_the_owner() {
 #[test]
 fn mutate_sealed() {
     new_test_ext().execute_with(|| {
-        let details = NFTDetails::new(vec![0, 1], 1);
+        let details = NFTDetails::new(vec![42], 1);
         let nft_id = 0;
 
         assert_ok!(NFTs::create(
@@ -98,7 +98,7 @@ fn mutate_sealed() {
         ));
         Data::<Test>::mutate(0, |d| d.sealed = true);
         assert_noop!(
-            NFTs::mutate(RawOrigin::Signed(ALICE).into(), nft_id, details,),
+            NFTs::mutate(RawOrigin::Signed(ALICE).into(), nft_id, details),
             Error::<Test>::Sealed
         );
     })

--- a/pallets/nfts/src/tests/spec.rs
+++ b/pallets/nfts/src/tests/spec.rs
@@ -1,5 +1,5 @@
 use super::mock::*;
-use crate::{Config, Data, Error, NFTData, NFTSeriesDetails};
+use crate::{Data, Error, NFTData, NFTDetails, NFTSeriesDetails, NFTSeriesId};
 use frame_support::{assert_noop, assert_ok};
 use frame_system::RawOrigin;
 
@@ -9,8 +9,7 @@ fn create_increment_id() {
         assert_eq!(NFTs::total(), 0);
         assert_ok!(NFTs::create(
             RawOrigin::Signed(ALICE).into(),
-            MockNFTDetails::Empty,
-            Default::default(),
+            NFTDetails::default(),
         ));
         assert_eq!(NFTs::total(), 1);
     })
@@ -19,13 +18,13 @@ fn create_increment_id() {
 #[test]
 fn create_register_details() {
     new_test_ext().execute_with(|| {
-        let mock_details = MockNFTDetails::WithU8(42);
+        let details = NFTDetails::new(vec![0, 1], 1);
+
         assert_ok!(NFTs::create(
             RawOrigin::Signed(ALICE).into(),
-            mock_details.clone(),
-            Default::default(),
+            details.clone(),
         ));
-        assert_eq!(NFTs::data(0).details, mock_details);
+        assert_eq!(NFTs::data(0).details, details);
     })
 }
 
@@ -34,8 +33,7 @@ fn create_register_owner() {
     new_test_ext().execute_with(|| {
         assert_ok!(NFTs::create(
             RawOrigin::Signed(ALICE).into(),
-            MockNFTDetails::Empty,
-            Default::default(),
+            NFTDetails::default(),
         ));
         assert_eq!(NFTs::data(0).owner, ALICE);
     })
@@ -46,8 +44,7 @@ fn create_is_unsealed() {
     new_test_ext().execute_with(|| {
         assert_ok!(NFTs::create(
             RawOrigin::Signed(ALICE).into(),
-            MockNFTDetails::Empty,
-            Default::default(),
+            NFTDetails::default(),
         ));
         assert_eq!(NFTs::data(0).sealed, false);
     })
@@ -56,31 +53,34 @@ fn create_is_unsealed() {
 #[test]
 fn mutate_update_details() {
     new_test_ext().execute_with(|| {
-        let mock_details = MockNFTDetails::WithU8(42);
+        let details = NFTDetails::new(vec![0, 1], 1);
+        let nft_id = 0;
+
         assert_ok!(NFTs::create(
             RawOrigin::Signed(ALICE).into(),
-            MockNFTDetails::Empty,
-            Default::default(),
+            NFTDetails::default(),
         ));
         assert_ok!(NFTs::mutate(
             RawOrigin::Signed(ALICE).into(),
-            0,
-            mock_details.clone(),
+            nft_id,
+            details.clone(),
         ));
-        assert_eq!(NFTs::data(0).details, mock_details);
+        assert_eq!(NFTs::data(0).details, details);
     })
 }
 
 #[test]
 fn mutate_not_the_owner() {
     new_test_ext().execute_with(|| {
+        let details = NFTDetails::new(vec![0, 1], 1);
+        let nft_id = 0;
+
         assert_ok!(NFTs::create(
             RawOrigin::Signed(ALICE).into(),
-            MockNFTDetails::Empty,
-            Default::default(),
+            NFTDetails::default(),
         ));
         assert_noop!(
-            NFTs::mutate(RawOrigin::Signed(BOB).into(), 0, MockNFTDetails::WithU8(42),),
+            NFTs::mutate(RawOrigin::Signed(BOB).into(), nft_id, details),
             Error::<Test>::NotOwner
         );
     })
@@ -89,18 +89,16 @@ fn mutate_not_the_owner() {
 #[test]
 fn mutate_sealed() {
     new_test_ext().execute_with(|| {
+        let details = NFTDetails::new(vec![0, 1], 1);
+        let nft_id = 0;
+
         assert_ok!(NFTs::create(
             RawOrigin::Signed(ALICE).into(),
-            MockNFTDetails::Empty,
-            Default::default(),
+            NFTDetails::default(),
         ));
         Data::<Test>::mutate(0, |d| d.sealed = true);
         assert_noop!(
-            NFTs::mutate(
-                RawOrigin::Signed(ALICE).into(),
-                0,
-                MockNFTDetails::WithU8(42),
-            ),
+            NFTs::mutate(RawOrigin::Signed(ALICE).into(), nft_id, details,),
             Error::<Test>::Sealed
         );
     })
@@ -111,8 +109,7 @@ fn transfer_update_owner() {
     new_test_ext().execute_with(|| {
         assert_ok!(NFTs::create(
             RawOrigin::Signed(ALICE).into(),
-            MockNFTDetails::Empty,
-            Default::default(),
+            NFTDetails::default(),
         ));
         assert_ok!(NFTs::transfer(RawOrigin::Signed(ALICE).into(), 0, BOB));
         assert_eq!(NFTs::data(0).owner, BOB);
@@ -124,8 +121,7 @@ fn transfer_not_the_owner() {
     new_test_ext().execute_with(|| {
         assert_ok!(NFTs::create(
             RawOrigin::Signed(ALICE).into(),
-            MockNFTDetails::Empty,
-            Default::default(),
+            NFTDetails::default(),
         ));
         assert_noop!(
             NFTs::transfer(RawOrigin::Signed(BOB).into(), 0, BOB),
@@ -139,8 +135,7 @@ fn seal_mutate_seal_flag() {
     new_test_ext().execute_with(|| {
         assert_ok!(NFTs::create(
             RawOrigin::Signed(ALICE).into(),
-            MockNFTDetails::Empty,
-            Default::default(),
+            NFTDetails::default(),
         ));
         assert_ok!(NFTs::seal(RawOrigin::Signed(ALICE).into(), 0));
         assert_eq!(NFTs::data(0).sealed, true);
@@ -152,8 +147,7 @@ fn seal_not_the_owner() {
     new_test_ext().execute_with(|| {
         assert_ok!(NFTs::create(
             RawOrigin::Signed(ALICE).into(),
-            MockNFTDetails::Empty,
-            Default::default(),
+            NFTDetails::default(),
         ));
         assert_noop!(
             NFTs::seal(RawOrigin::Signed(BOB).into(), 0),
@@ -167,8 +161,7 @@ fn seal_already_sealed() {
     new_test_ext().execute_with(|| {
         assert_ok!(NFTs::create(
             RawOrigin::Signed(ALICE).into(),
-            MockNFTDetails::Empty,
-            Default::default(),
+            NFTDetails::default(),
         ));
         assert_ok!(NFTs::seal(RawOrigin::Signed(ALICE).into(), 0));
         assert_noop!(
@@ -181,17 +174,14 @@ fn seal_already_sealed() {
 #[test]
 fn burn_owned_nft() {
     new_test_ext().execute_with(|| {
-        let series_id = <Test as Config>::NFTSeriesId::from(1u32);
+        let series_id = NFTSeriesId::from(1u32);
         let nft_id = NFTs::total();
 
         let before_details = NFTSeriesDetails::new(ALICE, sp_std::vec![nft_id]);
         let after_details = NFTSeriesDetails::new(ALICE, sp_std::vec![]);
+        let details = NFTDetails::new(vec![], series_id);
 
-        assert_ok!(NFTs::create(
-            RawOrigin::Signed(ALICE).into(),
-            MockNFTDetails::Empty,
-            series_id,
-        ));
+        assert_ok!(NFTs::create(RawOrigin::Signed(ALICE).into(), details,));
         assert_eq!(NFTs::series(series_id), Some(before_details));
 
         assert_ok!(NFTs::burn(RawOrigin::Signed(ALICE).into(), nft_id));
@@ -205,8 +195,7 @@ fn burn_not_owned_nft() {
     new_test_ext().execute_with(|| {
         assert_ok!(NFTs::create(
             RawOrigin::Signed(ALICE).into(),
-            MockNFTDetails::Empty,
-            Default::default(),
+            NFTDetails::default(),
         ));
 
         let id = NFTs::total() - 1;
@@ -235,23 +224,23 @@ fn series_create() {
     new_test_ext().execute_with(|| {
         let alice = RawOrigin::Signed(ALICE);
 
-        let valid_id = <Test as Config>::NFTSeriesId::from(1u32);
-        let default_id = <Test as Config>::NFTSeriesId::default();
+        let valid_id = NFTSeriesId::from(1u32);
+        let default_id = NFTSeriesId::default();
 
         let details = NFTSeriesDetails::new(ALICE, sp_std::vec![1u32, 2u32]);
+        let valid_nft_details = NFTDetails::new(vec![], valid_id);
+        let default_nft_details = NFTDetails::new(vec![], default_id);
 
         // Alice can create an nft that belongs to the default series.
         assert_ok!(NFTs::create(
             RawOrigin::Signed(ALICE).into(),
-            Default::default(),
-            default_id,
+            default_nft_details,
         ));
 
         // Alice can create a new nft series by creating an nft with a unused series id.
         assert_ok!(NFTs::create(
             RawOrigin::Signed(ALICE).into(),
-            Default::default(),
-            valid_id,
+            valid_nft_details.clone(),
         ));
         assert_eq!(NFTs::series(valid_id).unwrap().owner, ALICE);
 
@@ -259,14 +248,13 @@ fn series_create() {
         // wants.
         assert_ok!(NFTs::create(
             RawOrigin::Signed(ALICE).into(),
-            Default::default(),
-            valid_id,
+            valid_nft_details.clone(),
         ));
         assert_eq!(NFTs::series(valid_id), Some(details.clone()));
 
         // Bob cannot create an nft under a series that he does not own.
         assert_noop!(
-            NFTs::create(RawOrigin::Signed(BOB).into(), Default::default(), valid_id),
+            NFTs::create(RawOrigin::Signed(BOB).into(), valid_nft_details),
             Error::<Test>::NotSeriesOwner
         );
 
@@ -284,16 +272,15 @@ fn transfer_series() {
     new_test_ext().execute_with(|| {
         let alice = RawOrigin::Signed(ALICE);
 
-        let valid_id = <Test as Config>::NFTSeriesId::from(1u32);
-        let invalid_id = <Test as Config>::NFTSeriesId::from(10u32);
-        let default_id = <Test as Config>::NFTSeriesId::default();
+        let valid_id = NFTSeriesId::from(1u32);
+        let invalid_id = NFTSeriesId::from(10u32);
+        let default_id = NFTSeriesId::default();
 
         let bob_details = NFTSeriesDetails::new(BOB, sp_std::vec![0u32]);
 
         assert_ok!(NFTs::create(
             RawOrigin::Signed(ALICE).into(),
-            Default::default(),
-            valid_id,
+            NFTDetails::new(vec![], valid_id),
         ));
 
         // Since Alice owns the series she can transfer it to Bob.

--- a/pallets/nfts/src/tests/traits.rs
+++ b/pallets/nfts/src/tests/traits.rs
@@ -1,4 +1,5 @@
 use super::mock::*;
+use crate::types::NFTDetails;
 use crate::Error;
 use frame_support::{assert_noop, assert_ok};
 use frame_system::RawOrigin;
@@ -7,8 +8,8 @@ use ternoa_common::traits;
 #[test]
 fn set_owner() {
     new_test_ext().execute_with(|| {
-        let id = <NFTs as traits::NFTs>::create(&ALICE, MockNFTDetails::Empty, Default::default())
-            .expect("creation failed");
+        let id =
+            <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::default()).expect("creation failed");
 
         assert_ok!(<NFTs as traits::NFTs>::set_owner(id, &BOB));
         assert_eq!(<NFTs as traits::NFTs>::owner(id), BOB);
@@ -18,8 +19,8 @@ fn set_owner() {
 #[test]
 fn seal() {
     new_test_ext().execute_with(|| {
-        let id = <NFTs as traits::NFTs>::create(&ALICE, MockNFTDetails::Empty, Default::default())
-            .expect("creation failed");
+        let id =
+            <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::default()).expect("creation failed");
 
         assert_ok!(<NFTs as traits::NFTs>::seal(id));
         assert_eq!(<NFTs as traits::NFTs>::sealed(id), true);
@@ -33,8 +34,8 @@ fn seal() {
 #[test]
 fn lock_and_unlock() {
     new_test_ext().execute_with(|| {
-        let id = <NFTs as traits::NFTs>::create(&ALICE, MockNFTDetails::Empty, Default::default())
-            .expect("creation failed");
+        let id =
+            <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::default()).expect("creation failed");
 
         assert_ok!(<NFTs as traits::LockableNFTs>::lock(id));
         assert_eq!(<NFTs as traits::LockableNFTs>::locked(id), true);
@@ -47,8 +48,8 @@ fn lock_and_unlock() {
 #[test]
 fn lock_prevent_transfers() {
     new_test_ext().execute_with(|| {
-        let id = <NFTs as traits::NFTs>::create(&ALICE, MockNFTDetails::Empty, Default::default())
-            .expect("creation failed");
+        let id =
+            <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::default()).expect("creation failed");
 
         assert_ok!(<NFTs as traits::LockableNFTs>::lock(id));
         assert_noop!(
@@ -61,8 +62,8 @@ fn lock_prevent_transfers() {
 #[test]
 fn lock_prevent_set_owner() {
     new_test_ext().execute_with(|| {
-        let id = <NFTs as traits::NFTs>::create(&ALICE, MockNFTDetails::Empty, Default::default())
-            .expect("creation failed");
+        let id =
+            <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::default()).expect("creation failed");
 
         assert_ok!(<NFTs as traits::LockableNFTs>::lock(id));
         assert_noop!(
@@ -75,8 +76,8 @@ fn lock_prevent_set_owner() {
 #[test]
 fn lock_double_fail() {
     new_test_ext().execute_with(|| {
-        let id = <NFTs as traits::NFTs>::create(&ALICE, MockNFTDetails::Empty, Default::default())
-            .expect("creation failed");
+        let id =
+            <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::default()).expect("creation failed");
 
         assert_ok!(<NFTs as traits::LockableNFTs>::lock(id));
         assert_noop!(
@@ -89,8 +90,8 @@ fn lock_double_fail() {
 #[test]
 fn burn_nft() {
     new_test_ext().execute_with(|| {
-        let id = <NFTs as traits::NFTs>::create(&ALICE, MockNFTDetails::Empty, Default::default())
-            .expect("creation failed");
+        let id =
+            <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::default()).expect("creation failed");
 
         assert_ne!(<NFTs as traits::NFTs>::owner(id), 0);
         assert_ok!(<NFTs as traits::NFTs>::burn(id));
@@ -107,7 +108,7 @@ fn series_length() {
 
         let count = 3;
         for _ in 0..count {
-            let _ = <NFTs as traits::NFTs>::create(&ALICE, MockNFTDetails::Empty, valid_id)
+            let _ = <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::new(vec![], valid_id))
                 .expect("creation failed");
         }
 
@@ -128,11 +129,12 @@ fn series_id() {
         let valid_id = <NFTs as traits::NFTs>::NFTSeriesId::from(1u32);
         let default_id = <NFTs as traits::NFTs>::NFTSeriesId::default();
 
-        let valid_nft_id = <NFTs as traits::NFTs>::create(&ALICE, MockNFTDetails::Empty, valid_id)
-            .expect("creation failed");
+        let valid_nft_id =
+            <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::new(vec![], valid_id))
+                .expect("creation failed");
         let invalid_nft_id = <NFTs as traits::NFTs>::NFTId::from(100u32);
         let default_nft_id =
-            <NFTs as traits::NFTs>::create(&ALICE, MockNFTDetails::Empty, default_id)
+            <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::new(vec![], default_id))
                 .expect("creation failed");
 
         // Existing nft ids should return valid non default series ids.
@@ -159,7 +161,7 @@ fn series_owner() {
         let invalid_id = <NFTs as traits::NFTs>::NFTSeriesId::from(2u32);
         let default_id = <NFTs as traits::NFTs>::NFTSeriesId::default();
 
-        let _ = <NFTs as traits::NFTs>::create(&ALICE, MockNFTDetails::Empty, valid_id)
+        let _ = <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::new(vec![], valid_id))
             .expect("creation failed");
 
         // Existing ids should return the creator of the series as owner.
@@ -180,7 +182,7 @@ fn set_series_owner() {
         let invalid_id = <NFTs as traits::NFTs>::NFTSeriesId::from(2u32);
         let default_id = <NFTs as traits::NFTs>::NFTSeriesId::default();
 
-        let _ = <NFTs as traits::NFTs>::create(&ALICE, MockNFTDetails::Empty, valid_id)
+        let _ = <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::new(vec![], valid_id))
             .expect("creation failed");
 
         // It is possible to change owners of existing series.

--- a/pallets/nfts/src/types.rs
+++ b/pallets/nfts/src/types.rs
@@ -1,0 +1,26 @@
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
+
+use codec::{Decode, Encode};
+use sp_std::vec::Vec;
+
+/// How the NFT series id is encoded.
+pub type NFTSeriesId = u32;
+
+/// Data related to NFTs on the Ternoa Chain.
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Default, Debug)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct NFTDetails {
+    /// ASCII encoded URI to fetch additional metadata
+    pub offchain_uri: Vec<u8>,
+    pub series_id: NFTSeriesId,
+}
+
+impl NFTDetails {
+    pub fn new(offchain_uri: Vec<u8>, series_id: NFTSeriesId) -> Self {
+        Self {
+            offchain_uri,
+            series_id,
+        }
+    }
+}

--- a/pallets/nfts/src/types.rs
+++ b/pallets/nfts/src/types.rs
@@ -17,7 +17,7 @@ pub struct NFTDetails {
 }
 
 impl NFTDetails {
-    pub fn new(offchain_uri: Vec<u8>, series_id: NFTSeriesId) -> Self {
+    pub const fn new(offchain_uri: Vec<u8>, series_id: NFTSeriesId) -> Self {
         Self {
             offchain_uri,
             series_id,

--- a/pallets/timed-escrow/src/benchmarking.rs
+++ b/pallets/timed-escrow/src/benchmarking.rs
@@ -9,7 +9,6 @@ fn create_nft<T: Config>(caller: &T::AccountId) -> NFTIdOf<T> {
     T::NFTs::create(
         caller,
         <<T::NFTs as NFTs>::NFTDetails as Default>::default(),
-        Default::default(),
     )
     .expect("shall not fail with a clean state")
 }

--- a/pallets/timed-escrow/src/tests/mock.rs
+++ b/pallets/timed-escrow/src/tests/mock.rs
@@ -70,9 +70,7 @@ impl pallet_scheduler::Config for Test {
 impl ternoa_nfts::Config for Test {
     type Event = Event;
     type NFTId = u8;
-    type NFTDetails = ();
     type WeightInfo = ();
-    type NFTSeriesId = u32;
 }
 impl Config for Test {
     type Event = Event;
@@ -98,7 +96,6 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 pub fn create_one_capsule() {
     assert_ok!(<NFTs as ternoa_common::traits::NFTs>::create(
         &ALICE,
-        (),
         Default::default(),
     ));
 }

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -2,15 +2,11 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::{Decode, Encode};
-#[cfg(feature = "std")]
-use serde::{Deserialize, Serialize};
 use sp_runtime::{
     generic,
     traits::{BlakeTwo256, IdentifyAccount, Verify},
     MultiSignature, OpaqueExtrinsic,
 };
-use sp_std::prelude::Vec;
 
 /// An index to a block.
 pub type BlockNumber = u32;
@@ -39,15 +35,5 @@ pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 /// Block type.
 pub type Block = generic::Block<Header, OpaqueExtrinsic>;
 
-/// Data related to NFTs on the Ternoa Chain.
-#[derive(Encode, Decode, Clone, PartialEq, Eq, Default, Debug)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct NFTDetails {
-    /// ASCII encoded URI to fetch additional metadata
-    pub offchain_uri: Vec<u8>,
-}
-
 /// How NFT IDs are encoded.
 pub type NFTId = u32;
-/// How the NFT series id is encoded.
-pub type NFTSeriesId = u32;

--- a/runtime/src/pallets_ternoa.rs
+++ b/runtime/src/pallets_ternoa.rs
@@ -1,12 +1,10 @@
 use crate::{Balances, Call, Event, Nfts, OriginCaller, Runtime, Scheduler};
-use ternoa_primitives::{NFTDetails, NFTId, NFTSeriesId};
+use ternoa_primitives::NFTId;
 
 impl ternoa_nfts::Config for Runtime {
     type Event = Event;
     type NFTId = NFTId;
-    type NFTDetails = NFTDetails;
     type WeightInfo = ();
-    type NFTSeriesId = NFTSeriesId;
 }
 
 impl ternoa_timed_escrow::Config for Runtime {

--- a/runtime/src/version.rs
+++ b/runtime/src/version.rs
@@ -16,7 +16,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // and set impl_version to 0. If only runtime
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
-    spec_version: 9,
+    spec_version: 10,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/types.json
+++ b/types.json
@@ -7,11 +7,11 @@
         "owner": "AccountId",
         "details": "NFTDetails",
         "sealed": "bool",
-        "locked": "bool",
-        "series_id": "NFTSeriesId"
+        "locked": "bool"
     },
     "NFTDetails": {
-        "offchain_uri": "Vec<u8>"
+        "offchain_uri": "Vec<u8>",
+        "series_id": "NFTSeriesId"
     },
     "LookupSource": "AccountId",
     "NFTSeriesDetails": {


### PR DESCRIPTION
For ergonomic reason, I moved series id out of `NFTData` and into `NFTDetails`.

Also, `Created` event now contains series id.