### PR TITLE
Marko/implement capsule type nfts

### DIFF
--- a/common/src/nfts.rs
+++ b/common/src/nfts.rs
@@ -59,7 +59,7 @@ pub trait NFTs {
     /// Set the owner of a NFT series.
     fn set_series_owner(id: Self::NFTSeriesId, owner: &Self::AccountId) -> DispatchResult;
 
-    /// TODO!
+    /// Check wether an NFT is a capsule.
     fn is_capsule(id: Self::NFTId) -> bool;
 }
 

--- a/common/src/nfts.rs
+++ b/common/src/nfts.rs
@@ -17,6 +17,9 @@ pub trait NFTs {
     /// How the NFT series id is represented internally.
     type NFTSeriesId: Parameter + Copy + Default;
 
+    /// TODO!
+    type Protocol: Parameter + Copy + Default;
+
     /// Create a new NFT with the specified details and return its ID or an error.
     fn create(
         owner: &Self::AccountId,
@@ -58,6 +61,12 @@ pub trait NFTs {
 
     /// Set the owner of a NFT series.
     fn set_series_owner(id: Self::NFTSeriesId, owner: &Self::AccountId) -> DispatchResult;
+
+    /// TODO!
+    fn is_capsule(id: Self::NFTId) -> bool;
+
+    /// TODO!
+    fn protocol(id: Self::NFTId) -> Option<Self::Protocol>;
 }
 
 /// Implemented by a pallet where it is possible to lock NFTs.

--- a/common/src/nfts.rs
+++ b/common/src/nfts.rs
@@ -17,9 +17,6 @@ pub trait NFTs {
     /// How the NFT series id is represented internally.
     type NFTSeriesId: Parameter + Copy + Default;
 
-    /// TODO!
-    type Protocol: Parameter + Copy + Default;
-
     /// Create a new NFT with the specified details and return its ID or an error.
     fn create(
         owner: &Self::AccountId,
@@ -64,9 +61,6 @@ pub trait NFTs {
 
     /// TODO!
     fn is_capsule(id: Self::NFTId) -> bool;
-
-    /// TODO!
-    fn protocol(id: Self::NFTId) -> Option<Self::Protocol>;
 }
 
 /// Implemented by a pallet where it is possible to lock NFTs.

--- a/pallets/nfts/src/benchmarking.rs
+++ b/pallets/nfts/src/benchmarking.rs
@@ -18,7 +18,7 @@ benchmarks! {
     create_with_series {
         let caller: T::AccountId = whitelisted_caller();
         let series_id = NFTSeriesId::from(1u32);
-        let details = NFTDetails::new(vec![], series_id);
+        let details = NFTDetails::new(vec![], series_id, false, None);
 
         T::Currency::make_free_balance_be(&caller, T::MintFee::get() + T::Currency::minimum_balance());
     }: create(RawOrigin::Signed(caller.clone()), details)
@@ -70,7 +70,7 @@ benchmarks! {
     burn {
         let caller: T::AccountId = whitelisted_caller();
         let series_id = NFTSeriesId::from(1u32);
-        let details = NFTDetails::new(vec![], series_id);
+        let details = NFTDetails::new(vec![], series_id, false, None);
         let nft_id = T::NFTId::from(0);
 
         T::Currency::make_free_balance_be(&caller, T::MintFee::get() + T::Currency::minimum_balance());
@@ -86,7 +86,7 @@ benchmarks! {
 
         let caller: T::AccountId = whitelisted_caller();
         let series_id = NFTSeriesId::from(1u32);
-        let details = NFTDetails::new(vec![], series_id);
+        let details = NFTDetails::new(vec![], series_id, false, None);
 
         T::Currency::make_free_balance_be(&caller, T::MintFee::get() + T::Currency::minimum_balance());
         drop(Module::<T>::create(RawOrigin::Signed(caller.clone()).into(), details));

--- a/pallets/nfts/src/benchmarking.rs
+++ b/pallets/nfts/src/benchmarking.rs
@@ -18,7 +18,7 @@ benchmarks! {
     create_with_series {
         let caller: T::AccountId = whitelisted_caller();
         let series_id = NFTSeriesId::from(1u32);
-        let details = NFTDetails::new(vec![], series_id, false, None);
+        let details = NFTDetails::new(vec![], series_id, false);
 
         T::Currency::make_free_balance_be(&caller, T::MintFee::get() + T::Currency::minimum_balance());
     }: create(RawOrigin::Signed(caller.clone()), details)
@@ -70,7 +70,7 @@ benchmarks! {
     burn {
         let caller: T::AccountId = whitelisted_caller();
         let series_id = NFTSeriesId::from(1u32);
-        let details = NFTDetails::new(vec![], series_id, false, None);
+        let details = NFTDetails::new(vec![], series_id, false);
         let nft_id = T::NFTId::from(0);
 
         T::Currency::make_free_balance_be(&caller, T::MintFee::get() + T::Currency::minimum_balance());
@@ -86,7 +86,7 @@ benchmarks! {
 
         let caller: T::AccountId = whitelisted_caller();
         let series_id = NFTSeriesId::from(1u32);
-        let details = NFTDetails::new(vec![], series_id, false, None);
+        let details = NFTDetails::new(vec![], series_id, false);
 
         T::Currency::make_free_balance_be(&caller, T::MintFee::get() + T::Currency::minimum_balance());
         drop(Module::<T>::create(RawOrigin::Signed(caller.clone()).into(), details));

--- a/pallets/nfts/src/lib.rs
+++ b/pallets/nfts/src/lib.rs
@@ -286,6 +286,7 @@ impl<T: Config> NFTs for Pallet<T> {
     type NFTDetails = NFTDetails;
     type NFTId = T::NFTId;
     type NFTSeriesId = NFTSeriesId;
+    type Protocol = Protocol;
 
     fn create(
         owner: &Self::AccountId,
@@ -412,6 +413,14 @@ impl<T: Config> NFTs for Pallet<T> {
         });
 
         Ok(())
+    }
+
+    fn is_capsule(id: Self::NFTId) -> bool {
+        Data::<T>::get(id).details.is_capsule
+    }
+
+    fn protocol(id: Self::NFTId) -> Option<Self::Protocol> {
+        Data::<T>::get(id).details.protocol
     }
 }
 

--- a/pallets/nfts/src/tests/genesis.rs
+++ b/pallets/nfts/src/tests/genesis.rs
@@ -10,7 +10,7 @@ fn register_nfts() {
         .unwrap();
 
     GenesisConfig::<Test> {
-        nfts: vec![(ALICE, NFTDetails::new(vec![1], 0, false, None))],
+        nfts: vec![(ALICE, NFTDetails::new(vec![1], 0, false))],
         series: vec![],
     }
     .assimilate_storage(&mut t)
@@ -20,10 +20,7 @@ fn register_nfts() {
     ext.execute_with(|| {
         assert_eq!(NFTs::total(), 1);
         assert_eq!(NFTs::data(0).owner, ALICE);
-        assert_eq!(
-            NFTs::data(0).details,
-            NFTDetails::new(vec![1], 0, false, None)
-        );
+        assert_eq!(NFTs::data(0).details, NFTDetails::new(vec![1], 0, false));
         assert_eq!(NFTs::data(0).locked, false);
         assert_eq!(NFTs::data(0).sealed, false);
     });

--- a/pallets/nfts/src/tests/genesis.rs
+++ b/pallets/nfts/src/tests/genesis.rs
@@ -10,7 +10,7 @@ fn register_nfts() {
         .unwrap();
 
     GenesisConfig::<Test> {
-        nfts: vec![(ALICE, NFTDetails::new(vec![1], 0))],
+        nfts: vec![(ALICE, NFTDetails::new(vec![1], 0, false, None))],
         series: vec![],
     }
     .assimilate_storage(&mut t)
@@ -20,7 +20,10 @@ fn register_nfts() {
     ext.execute_with(|| {
         assert_eq!(NFTs::total(), 1);
         assert_eq!(NFTs::data(0).owner, ALICE);
-        assert_eq!(NFTs::data(0).details, NFTDetails::new(vec![1], 0));
+        assert_eq!(
+            NFTs::data(0).details,
+            NFTDetails::new(vec![1], 0, false, None)
+        );
         assert_eq!(NFTs::data(0).locked, false);
         assert_eq!(NFTs::data(0).sealed, false);
     });

--- a/pallets/nfts/src/tests/spec.rs
+++ b/pallets/nfts/src/tests/spec.rs
@@ -361,38 +361,12 @@ fn transfer_series() {
 }
 
 #[test]
-fn cannot_create_if_not_enough_funds_to_pay_for_fees() {
-    ExtBuilder::default().build().execute_with(|| {
-        assert_noop!(
-            NFTs::create(
-                RawOrigin::Signed(ALICE).into(),
-                NFTDetails::new(vec![], 0, true, Some(Protocol::Safe))
-            ),
-            Error::<Test>::InsufficientFunds
-        );
-    })
-}
-
-#[test]
-fn fees_are_passed_to_collector() {
-    ExtBuilder::default()
-        .one_hundred_for_everyone()
-        .build()
-        .execute_with(|| {
-            assert_ok!(NFTs::create(
-                RawOrigin::Signed(ALICE).into(),
-                NFTDetails::new(vec![], 0, true, Some(Protocol::Safe)),
-            ));
-            assert_eq!(Balances::free_balance(&COLLECTOR), MintFee::get());
-        })
-}
-
-#[test]
 fn mint_fees() {
     ExtBuilder::default()
         .one_hundred_for_everyone()
         .build()
         .execute_with(|| {
+            // Setting up the stage
             const INITIAL_FUNDS: u64 = 100u64;
             const FEE: u64 = MintFee::get();
             const NEW_FUNDS: u64 = INITIAL_FUNDS - FEE;
@@ -401,24 +375,24 @@ fn mint_fees() {
             let alice: Origin = RawOrigin::Signed(ALICE).into();
             let bob: Origin = RawOrigin::Signed(BOB).into();
 
-            // Alice will not pay additional mint fees if she wants to create non-capsule like nfts.
+            const SERIES_ID: u32 = 1u32;
+            assert_ok!(NFTs::create(
+                bob.clone(),
+                NFTDetails::new(vec![], SERIES_ID, false, None)
+            ));
+
+            // Alice will not pay additional mint fees if she wants to create non-capsule nfts.
             assert_ok!(NFTs::create(alice.clone(), NFTDetails::default()));
             assert_eq!(Balances::free_balance(&COLLECTOR), 0u64);
             assert_eq!(Balances::free_balance(&ALICE), INITIAL_FUNDS);
 
-            // Alice will pay additional mint fees if she wants to create capsule like nfts.
+            // Alice will pay additional mint fees if she wants to create capsule nfts.
             assert_ok!(NFTs::create(
                 alice.clone(),
                 NFTDetails::new(vec![], 0, true, Some(PROTOCOL)),
             ));
             assert_eq!(Balances::free_balance(&COLLECTOR), FEE);
             assert_eq!(Balances::free_balance(&ALICE), NEW_FUNDS);
-
-            let series_id = 1u32;
-            assert_ok!(NFTs::create(
-                bob.clone(),
-                NFTDetails::new(vec![], series_id, false, None)
-            ));
 
             // Alice will not pay any fees if the create function fails.
             assert_noop!(
@@ -428,10 +402,44 @@ fn mint_fees() {
             assert_noop!(
                 NFTs::create(
                     alice.clone(),
-                    NFTDetails::new(vec![], series_id, true, Some(PROTOCOL))
+                    NFTDetails::new(vec![], SERIES_ID, true, Some(PROTOCOL))
                 ),
                 Error::<Test>::NotSeriesOwner
             );
             assert_eq!(Balances::free_balance(&ALICE), NEW_FUNDS);
+        })
+}
+
+#[test]
+fn create_capsule() {
+    ExtBuilder::default()
+        .one_hundred_for_everyone()
+        .build()
+        .execute_with(|| {
+            // Setting up the stage
+            const PROTOCOL: Protocol = Protocol::Safe;
+            let alice: Origin = RawOrigin::Signed(ALICE).into();
+
+            assert_ok!(NFTs::create(
+                alice.clone(),
+                NFTDetails::new(vec![], 0, true, Some(PROTOCOL))
+            ));
+
+            // Alice cannot create a capsule if she didn't chose a protocol.
+            assert_noop!(
+                NFTs::create(alice.clone(), NFTDetails::new(vec![], 0, true, None)),
+                Error::<Test>::ProtocolNotEntered
+            );
+
+            // Alice cannot create a capsule if she doesn't have enough money.
+            let funds = Balances::free_balance(ALICE);
+            assert_ok!(Balances::transfer(alice.clone(), BOB, funds));
+            assert_noop!(
+                NFTs::create(
+                    alice.clone(),
+                    NFTDetails::new(vec![], 0, true, Some(PROTOCOL))
+                ),
+                Error::<Test>::InsufficientFunds
+            );
         })
 }

--- a/pallets/nfts/src/tests/spec.rs
+++ b/pallets/nfts/src/tests/spec.rs
@@ -395,17 +395,12 @@ fn mint_fees() {
             assert_eq!(Balances::free_balance(&ALICE), NEW_FUNDS);
 
             // Alice will not pay any fees if the create function fails.
-            assert_noop!(
-                NFTs::create(alice.clone(), NFTDetails::new(vec![], 0, true, None)),
-                Error::<Test>::ProtocolNotEntered
-            );
-            assert_noop!(
-                NFTs::create(
-                    alice.clone(),
-                    NFTDetails::new(vec![], SERIES_ID, true, Some(PROTOCOL))
-                ),
-                Error::<Test>::NotSeriesOwner
-            );
+            assert!(NFTs::create(alice.clone(), NFTDetails::new(vec![], 0, true, None)).is_err());
+            assert!(NFTs::create(
+                alice.clone(),
+                NFTDetails::new(vec![], SERIES_ID, true, Some(PROTOCOL))
+            )
+            .is_err());
             assert_eq!(Balances::free_balance(&ALICE), NEW_FUNDS);
         })
 }

--- a/pallets/nfts/src/tests/spec.rs
+++ b/pallets/nfts/src/tests/spec.rs
@@ -386,7 +386,7 @@ fn mint_fees() {
             assert_eq!(Balances::free_balance(&COLLECTOR), 0u64);
             assert_eq!(Balances::free_balance(&ALICE), INITIAL_FUNDS);
 
-            // Alice will pay additional mint fees if she wants to create capsule nfts.
+            // Alice will pay additional mint fees if she wants to create a capsule.
             assert_ok!(NFTs::create(
                 alice.clone(),
                 NFTDetails::new(vec![], 0, true, Some(PROTOCOL)),

--- a/pallets/nfts/src/tests/spec.rs
+++ b/pallets/nfts/src/tests/spec.rs
@@ -1,5 +1,5 @@
 use super::mock::*;
-use crate::{Data, Error, NFTData, NFTDetails, NFTSeriesDetails, NFTSeriesId, Protocol};
+use crate::{Data, Error, NFTData, NFTDetails, NFTSeriesDetails, NFTSeriesId};
 use frame_support::{assert_noop, assert_ok};
 use frame_system::RawOrigin;
 
@@ -24,7 +24,7 @@ fn create_register_details() {
         .one_hundred_for_everyone()
         .build()
         .execute_with(|| {
-            let details = NFTDetails::new(vec![42], 1, false, None);
+            let details = NFTDetails::new(vec![42], 1, false);
 
             assert_ok!(NFTs::create(
                 RawOrigin::Signed(ALICE).into(),
@@ -68,7 +68,7 @@ fn mutate_update_details() {
         .one_hundred_for_everyone()
         .build()
         .execute_with(|| {
-            let details = NFTDetails::new(vec![42], 1, false, None);
+            let details = NFTDetails::new(vec![42], 1, false);
             let nft_id = 0;
 
             assert_ok!(NFTs::create(
@@ -90,7 +90,7 @@ fn mutate_not_the_owner() {
         .one_hundred_for_everyone()
         .build()
         .execute_with(|| {
-            let details = NFTDetails::new(vec![42], 1, false, None);
+            let details = NFTDetails::new(vec![42], 1, false);
             let nft_id = 0;
 
             assert_ok!(NFTs::create(
@@ -110,7 +110,7 @@ fn mutate_sealed() {
         .one_hundred_for_everyone()
         .build()
         .execute_with(|| {
-            let details = NFTDetails::new(vec![42], 1, false, None);
+            let details = NFTDetails::new(vec![42], 1, false);
             let nft_id = 0;
 
             assert_ok!(NFTs::create(
@@ -218,7 +218,7 @@ fn burn_owned_nft() {
 
             let before_details = NFTSeriesDetails::new(ALICE, sp_std::vec![nft_id]);
             let after_details = NFTSeriesDetails::new(ALICE, sp_std::vec![]);
-            let details = NFTDetails::new(vec![], series_id, false, None);
+            let details = NFTDetails::new(vec![], series_id, false);
 
             assert_ok!(NFTs::create(RawOrigin::Signed(ALICE).into(), details));
             assert_eq!(NFTs::series(series_id), Some(before_details));
@@ -276,8 +276,8 @@ fn series_create() {
             let default_id = NFTSeriesId::default();
 
             let details = NFTSeriesDetails::new(ALICE, sp_std::vec![1u32, 2u32]);
-            let valid_nft_details = NFTDetails::new(vec![], valid_id, false, None);
-            let default_nft_details = NFTDetails::new(vec![], default_id, false, None);
+            let valid_nft_details = NFTDetails::new(vec![], valid_id, false);
+            let default_nft_details = NFTDetails::new(vec![], default_id, false);
 
             // Alice can create an nft that belongs to the default series.
             assert_ok!(NFTs::create(
@@ -331,7 +331,7 @@ fn transfer_series() {
 
             assert_ok!(NFTs::create(
                 RawOrigin::Signed(ALICE).into(),
-                NFTDetails::new(vec![], valid_id, false, None),
+                NFTDetails::new(vec![], valid_id, false)
             ));
 
             // Since Alice owns the series she can transfer it to Bob.
@@ -369,39 +369,32 @@ fn mint_fees() {
             // Setting up the stage
             const INITIAL_FUNDS: u64 = 100u64;
             const FEE: u64 = MintFee::get();
-            const NEW_FUNDS: u64 = INITIAL_FUNDS - FEE;
-            const PROTOCOL: Protocol = Protocol::Safe;
+            const NEW_FUNDS_1: u64 = INITIAL_FUNDS - FEE;
+            const NEW_FUNDS_2: u64 = NEW_FUNDS_1 - FEE;
 
             let alice: Origin = RawOrigin::Signed(ALICE).into();
             let bob: Origin = RawOrigin::Signed(BOB).into();
 
             const SERIES_ID: u32 = 1u32;
-            assert_ok!(NFTs::create(
-                bob.clone(),
-                NFTDetails::new(vec![], SERIES_ID, false, None)
-            ));
+            assert_ok!(NFTs::create(bob, NFTDetails::new(vec![], SERIES_ID, false)));
+            assert_eq!(Balances::free_balance(&COLLECTOR), FEE);
 
-            // Alice will not pay additional mint fees if she wants to create non-capsule nfts.
+            // Alice will pay additional mint fees if she wants to create a normal nft.
             assert_ok!(NFTs::create(alice.clone(), NFTDetails::default()));
-            assert_eq!(Balances::free_balance(&COLLECTOR), 0u64);
-            assert_eq!(Balances::free_balance(&ALICE), INITIAL_FUNDS);
+            assert_eq!(Balances::free_balance(&COLLECTOR), FEE * 2);
+            assert_eq!(Balances::free_balance(&ALICE), NEW_FUNDS_1);
 
             // Alice will pay additional mint fees if she wants to create a capsule.
             assert_ok!(NFTs::create(
                 alice.clone(),
-                NFTDetails::new(vec![], 0, true, Some(PROTOCOL)),
+                NFTDetails::new(vec![], 0, true)
             ));
-            assert_eq!(Balances::free_balance(&COLLECTOR), FEE);
-            assert_eq!(Balances::free_balance(&ALICE), NEW_FUNDS);
+            assert_eq!(Balances::free_balance(&COLLECTOR), FEE * 3);
+            assert_eq!(Balances::free_balance(&ALICE), NEW_FUNDS_2);
 
             // Alice will not pay any fees if the create function fails.
-            assert!(NFTs::create(alice.clone(), NFTDetails::new(vec![], 0, true, None)).is_err());
-            assert!(NFTs::create(
-                alice.clone(),
-                NFTDetails::new(vec![], SERIES_ID, true, Some(PROTOCOL))
-            )
-            .is_err());
-            assert_eq!(Balances::free_balance(&ALICE), NEW_FUNDS);
+            assert!(NFTs::create(alice.clone(), NFTDetails::new(vec![], SERIES_ID, true)).is_err());
+            assert_eq!(Balances::free_balance(&ALICE), NEW_FUNDS_2);
         })
 }
 
@@ -412,29 +405,19 @@ fn create_capsule() {
         .build()
         .execute_with(|| {
             // Setting up the stage
-            const PROTOCOL: Protocol = Protocol::Safe;
             let alice: Origin = RawOrigin::Signed(ALICE).into();
 
             assert_ok!(NFTs::create(
                 alice.clone(),
-                NFTDetails::new(vec![], 0, true, Some(PROTOCOL))
+                NFTDetails::new(vec![], 0, true)
             ));
-
-            // Alice cannot create a capsule if she didn't chose a protocol.
-            assert_noop!(
-                NFTs::create(alice.clone(), NFTDetails::new(vec![], 0, true, None)),
-                Error::<Test>::ProtocolNotEntered
-            );
 
             // Alice cannot create a capsule if she doesn't have enough money.
             let funds = Balances::free_balance(ALICE);
             assert_ok!(Balances::transfer(alice.clone(), BOB, funds));
             assert_noop!(
-                NFTs::create(
-                    alice.clone(),
-                    NFTDetails::new(vec![], 0, true, Some(PROTOCOL))
-                ),
-                Error::<Test>::InsufficientFunds
+                NFTs::create(alice.clone(), NFTDetails::new(vec![], 0, true)),
+                pallet_balances::Error::<Test>::InsufficientBalance
             );
         })
 }

--- a/pallets/nfts/src/tests/traits.rs
+++ b/pallets/nfts/src/tests/traits.rs
@@ -108,8 +108,11 @@ fn series_length() {
 
         let count = 3;
         for _ in 0..count {
-            let _ = <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::new(vec![], valid_id))
-                .expect("creation failed");
+            let _ = <NFTs as traits::NFTs>::create(
+                &ALICE,
+                NFTDetails::new(vec![], valid_id, false, None),
+            )
+            .expect("creation failed");
         }
 
         // Existing ids should return valid length values.
@@ -130,12 +133,14 @@ fn series_id() {
         let default_id = <NFTs as traits::NFTs>::NFTSeriesId::default();
 
         let valid_nft_id =
-            <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::new(vec![], valid_id))
+            <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::new(vec![], valid_id, false, None))
                 .expect("creation failed");
         let invalid_nft_id = <NFTs as traits::NFTs>::NFTId::from(100u32);
-        let default_nft_id =
-            <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::new(vec![], default_id))
-                .expect("creation failed");
+        let default_nft_id = <NFTs as traits::NFTs>::create(
+            &ALICE,
+            NFTDetails::new(vec![], default_id, false, None),
+        )
+        .expect("creation failed");
 
         // Existing nft ids should return valid non default series ids.
         assert_eq!(
@@ -161,8 +166,9 @@ fn series_owner() {
         let invalid_id = <NFTs as traits::NFTs>::NFTSeriesId::from(2u32);
         let default_id = <NFTs as traits::NFTs>::NFTSeriesId::default();
 
-        let _ = <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::new(vec![], valid_id))
-            .expect("creation failed");
+        let _ =
+            <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::new(vec![], valid_id, false, None))
+                .expect("creation failed");
 
         // Existing ids should return the creator of the series as owner.
         assert_eq!(<NFTs as traits::NFTs>::series_owner(valid_id), Some(ALICE));
@@ -182,8 +188,9 @@ fn set_series_owner() {
         let invalid_id = <NFTs as traits::NFTs>::NFTSeriesId::from(2u32);
         let default_id = <NFTs as traits::NFTs>::NFTSeriesId::default();
 
-        let _ = <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::new(vec![], valid_id))
-            .expect("creation failed");
+        let _ =
+            <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::new(vec![], valid_id, false, None))
+                .expect("creation failed");
 
         // It is possible to change owners of existing series.
         assert_ok!(<NFTs as traits::NFTs>::set_series_owner(valid_id, &BOB));

--- a/pallets/nfts/src/tests/traits.rs
+++ b/pallets/nfts/src/tests/traits.rs
@@ -1,6 +1,6 @@
 use super::mock::*;
 use crate::types::NFTDetails;
-use crate::{Error, Protocol};
+use crate::Error;
 use frame_support::{assert_noop, assert_ok};
 use frame_system::RawOrigin;
 use ternoa_common::traits;
@@ -108,11 +108,9 @@ fn series_length() {
 
         let count = 3;
         for _ in 0..count {
-            let _ = <NFTs as traits::NFTs>::create(
-                &ALICE,
-                NFTDetails::new(vec![], valid_id, false, None),
-            )
-            .expect("creation failed");
+            let _ =
+                <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::new(vec![], valid_id, false))
+                    .expect("creation failed");
         }
 
         // Existing ids should return valid length values.
@@ -133,14 +131,12 @@ fn series_id() {
         let default_id = <NFTs as traits::NFTs>::NFTSeriesId::default();
 
         let valid_nft_id =
-            <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::new(vec![], valid_id, false, None))
+            <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::new(vec![], valid_id, false))
                 .expect("creation failed");
         let invalid_nft_id = <NFTs as traits::NFTs>::NFTId::from(100u32);
-        let default_nft_id = <NFTs as traits::NFTs>::create(
-            &ALICE,
-            NFTDetails::new(vec![], default_id, false, None),
-        )
-        .expect("creation failed");
+        let default_nft_id =
+            <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::new(vec![], default_id, false))
+                .expect("creation failed");
 
         // Existing nft ids should return valid non default series ids.
         assert_eq!(
@@ -166,9 +162,8 @@ fn series_owner() {
         let invalid_id = <NFTs as traits::NFTs>::NFTSeriesId::from(2u32);
         let default_id = <NFTs as traits::NFTs>::NFTSeriesId::default();
 
-        let _ =
-            <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::new(vec![], valid_id, false, None))
-                .expect("creation failed");
+        let _ = <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::new(vec![], valid_id, false))
+            .expect("creation failed");
 
         // Existing ids should return the creator of the series as owner.
         assert_eq!(<NFTs as traits::NFTs>::series_owner(valid_id), Some(ALICE));
@@ -188,9 +183,8 @@ fn set_series_owner() {
         let invalid_id = <NFTs as traits::NFTs>::NFTSeriesId::from(2u32);
         let default_id = <NFTs as traits::NFTs>::NFTSeriesId::default();
 
-        let _ =
-            <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::new(vec![], valid_id, false, None))
-                .expect("creation failed");
+        let _ = <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::new(vec![], valid_id, false))
+            .expect("creation failed");
 
         // It is possible to change owners of existing series.
         assert_ok!(<NFTs as traits::NFTs>::set_series_owner(valid_id, &BOB));
@@ -214,39 +208,17 @@ fn create_capsule() {
         .one_hundred_for_everyone()
         .build()
         .execute_with(|| {
-            // Setting up the stage
-            const SERIES_ID: u32 = 1;
-            const PROTOCOL: Option<Protocol> = Some(Protocol::Safe);
-
-            let _ = <NFTs as traits::NFTs>::create(
-                &BOB,
-                NFTDetails::new(vec![], SERIES_ID, false, None),
-            )
-            .expect("creation failed");
-
             // Valid values
-            let details = NFTDetails::new(vec![], 0, true, PROTOCOL);
+            let details = NFTDetails::new(vec![], 0, true);
             let id = <NFTs as traits::NFTs>::create(&ALICE, details).expect("creation failed");
             assert_eq!(<NFTs as traits::NFTs>::is_capsule(id), true);
-            assert_eq!(<NFTs as traits::NFTs>::protocol(id), PROTOCOL);
 
             // The default values
             let id = <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::default())
                 .expect("creation failed");
             assert_eq!(<NFTs as traits::NFTs>::is_capsule(id), false);
-            assert_eq!(<NFTs as traits::NFTs>::protocol(id), None);
 
-            // If for any reason the create function fails, Alice should not lose any money.
-            let funds: u64 = Balances::free_balance(ALICE);
-            assert!(
-                <NFTs as traits::NFTs>::create(&ALICE, NFTDetails::new(vec![], 0, true, None))
-                    .is_err()
-            );
-            assert!(<NFTs as traits::NFTs>::create(
-                &ALICE,
-                NFTDetails::new(vec![], SERIES_ID, true, PROTOCOL)
-            )
-            .is_err());
-            assert_eq!(Balances::free_balance(ALICE), funds);
+            // Unknown nft id value
+            assert_eq!(<NFTs as traits::NFTs>::is_capsule(23), false);
         })
 }

--- a/pallets/nfts/src/types.rs
+++ b/pallets/nfts/src/types.rs
@@ -7,23 +7,6 @@ use sp_std::vec::Vec;
 /// How the NFT series id is encoded.
 pub type NFTSeriesId = u32;
 
-/// TODO!
-#[derive(Encode, Decode, Copy, Clone, PartialEq, Eq, Debug)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub enum Protocol {
-    Safe = 1,
-    DDay = 2,
-    Consent = 3,
-    Death = 4,
-    Countdown = 5,
-}
-
-impl Default for Protocol {
-    fn default() -> Self {
-        Protocol::Safe
-    }
-}
-
 /// Data related to NFTs on the Ternoa Chain.
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Default, Debug)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
@@ -34,22 +17,14 @@ pub struct NFTDetails {
     pub series_id: NFTSeriesId,
     /// TODO!
     pub is_capsule: bool,
-    /// TODO!
-    pub protocol: Option<Protocol>,
 }
 
 impl NFTDetails {
-    pub fn new(
-        offchain_uri: Vec<u8>,
-        series_id: NFTSeriesId,
-        is_capsule: bool,
-        protocol: Option<Protocol>,
-    ) -> Self {
+    pub fn new(offchain_uri: Vec<u8>, series_id: NFTSeriesId, is_capsule: bool) -> Self {
         Self {
             offchain_uri,
             is_capsule,
             series_id,
-            protocol,
         }
     }
 

--- a/pallets/nfts/src/types.rs
+++ b/pallets/nfts/src/types.rs
@@ -11,11 +11,11 @@ pub type NFTSeriesId = u32;
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Default, Debug)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct NFTDetails {
-    /// ASCII encoded URI to fetch additional metadata
+    /// ASCII encoded URI to fetch additional metadata.
     pub offchain_uri: Vec<u8>,
-    /// TODO!
+    /// The series id that this nft belongs to.
     pub series_id: NFTSeriesId,
-    /// TODO!
+    /// Capsule flag.
     pub is_capsule: bool,
 }
 
@@ -28,6 +28,7 @@ impl NFTDetails {
         }
     }
 
+    /// Checks if the nft is a part of an unique series.
     pub fn unique_series(&self) -> bool {
         self.series_id != NFTSeriesId::default()
     }

--- a/pallets/nfts/src/types.rs
+++ b/pallets/nfts/src/types.rs
@@ -1,11 +1,28 @@
+use codec::{Decode, Encode};
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
-
-use codec::{Decode, Encode};
+use sp_runtime::RuntimeDebug;
 use sp_std::vec::Vec;
 
 /// How the NFT series id is encoded.
 pub type NFTSeriesId = u32;
+
+/// TODO!
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub enum Protocol {
+    Safe = 1,
+    DDay = 2,
+    Consent = 3,
+    Death = 4,
+    Countdown = 5,
+}
+
+impl Default for Protocol {
+    fn default() -> Self {
+        Protocol::Safe
+    }
+}
 
 /// Data related to NFTs on the Ternoa Chain.
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Default, Debug)]
@@ -13,14 +30,69 @@ pub type NFTSeriesId = u32;
 pub struct NFTDetails {
     /// ASCII encoded URI to fetch additional metadata
     pub offchain_uri: Vec<u8>,
+    /// TODO!
+    pub is_capsule: bool,
+    /// TODO!
     pub series_id: NFTSeriesId,
+    /// TODO!
+    pub protocol: Option<Protocol>,
 }
 
 impl NFTDetails {
-    pub const fn new(offchain_uri: Vec<u8>, series_id: NFTSeriesId) -> Self {
+    pub fn new(
+        offchain_uri: Vec<u8>,
+        is_capsule: bool,
+        series_id: NFTSeriesId,
+        protocol: Option<Protocol>,
+    ) -> Self {
         Self {
             offchain_uri,
             series_id,
+            is_capsule,
+            protocol,
         }
+    }
+
+    pub fn unique_series(&self) -> bool {
+        self.series_id != NFTSeriesId::default()
+    }
+}
+
+/// Data related to an NFT, such as who is its owner.
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct NFTData<AccountId, NFTDetails> {
+    pub owner: AccountId,
+    pub details: NFTDetails,
+    /// Set to true to prevent further modifications to the details struct
+    pub sealed: bool,
+    /// Set to true to prevent changes to the owner variable
+    pub locked: bool,
+}
+
+impl<AccountId, NFTDetails> NFTData<AccountId, NFTDetails> {
+    pub fn new(owner: AccountId, details: NFTDetails, sealed: bool, locked: bool) -> Self {
+        Self {
+            owner,
+            details,
+            sealed,
+            locked,
+        }
+    }
+}
+
+/// Data related to an NFT Series.
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct NFTSeriesDetails<AccountId, NFTId> {
+    // Series owner.
+    pub owner: AccountId,
+    // NFTs that are part of the same series.
+    pub nfts: Vec<NFTId>,
+}
+
+impl<AccountId, NFTId> NFTSeriesDetails<AccountId, NFTId> {
+    pub fn new(owner: AccountId, nfts: Vec<NFTId>) -> Self {
+        Self { owner, nfts }
     }
 }

--- a/pallets/nfts/src/types.rs
+++ b/pallets/nfts/src/types.rs
@@ -31,9 +31,9 @@ pub struct NFTDetails {
     /// ASCII encoded URI to fetch additional metadata
     pub offchain_uri: Vec<u8>,
     /// TODO!
-    pub is_capsule: bool,
-    /// TODO!
     pub series_id: NFTSeriesId,
+    /// TODO!
+    pub is_capsule: bool,
     /// TODO!
     pub protocol: Option<Protocol>,
 }
@@ -41,14 +41,14 @@ pub struct NFTDetails {
 impl NFTDetails {
     pub fn new(
         offchain_uri: Vec<u8>,
-        is_capsule: bool,
         series_id: NFTSeriesId,
+        is_capsule: bool,
         protocol: Option<Protocol>,
     ) -> Self {
         Self {
             offchain_uri,
-            series_id,
             is_capsule,
+            series_id,
             protocol,
         }
     }

--- a/pallets/nfts/src/types.rs
+++ b/pallets/nfts/src/types.rs
@@ -8,7 +8,7 @@ use sp_std::vec::Vec;
 pub type NFTSeriesId = u32;
 
 /// TODO!
-#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug)]
+#[derive(Encode, Decode, Copy, Clone, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum Protocol {
     Safe = 1,

--- a/runtime/src/version.rs
+++ b/runtime/src/version.rs
@@ -16,7 +16,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // and set impl_version to 0. If only runtime
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
-    spec_version: 15,
+    spec_version: 16,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/types.json
+++ b/types.json
@@ -4,15 +4,6 @@
     "NFTId": "u32",
     "NFTIdOf": "NFTId",
     "NFTSeriesId": "u32",
-    "Protocol": {
-        "_enum": [
-            "Safe",
-            "DDay",
-            "Consent",
-            "Death",
-            "Countdown"
-        ]
-    },
     "NFTData": {
         "owner": "AccountId",
         "details": "NFTDetails",
@@ -22,8 +13,7 @@
     "NFTDetails": {
         "offchain_uri": "Vec<u8>",
         "series_id": "NFTSeriesId",
-        "is_capsule": "bool",
-        "protocol": "Option<Protocol>"
+        "is_capsule": "bool"
     },
     "LookupSource": "AccountId",
     "NFTSeriesDetails": {

--- a/types.json
+++ b/types.json
@@ -4,6 +4,15 @@
     "NFTId": "u32",
     "NFTIdOf": "NFTId",
     "NFTSeriesId": "u32",
+    "Protocol": {
+        "_enum": [
+            "Safe",
+            "DDay",
+            "Consent",
+            "Death",
+            "Countdown"
+        ]
+    },
     "NFTData": {
         "owner": "AccountId",
         "details": "NFTDetails",
@@ -12,7 +21,9 @@
     },
     "NFTDetails": {
         "offchain_uri": "Vec<u8>",
-        "series_id": "NFTSeriesId"
+        "series_id": "NFTSeriesId",
+        "is_capsule": "bool",
+        "protocol": "Option<Protocol>"
     },
     "LookupSource": "AccountId",
     "NFTSeriesDetails": {


### PR DESCRIPTION
The documentation and requirements for this PR can be found [here](https://capsule-corp.atlassian.net/wiki/spaces/BLOC/pages/33059/CapsuleTime+files+worflow?focusedCommentId=295152).

This PR creates the necessary interface that enables the user to create capsules with a specific protocol type. As per request, protocol type is not mandatory when capsule like features are not needed. Much attention has been give to `create` trait function so that it doesn't slash money when the function fails. 

Documentation is missing and the weights are not recalculated but they will be recalculated once the core implementation is deemed valid/sound.

N.B. Before merging this PR, other teams need to be notified about the changes in the interface. 