### PR TITLE
gov. refactoring

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -14,7 +14,7 @@ use ternoa_primitives::{AccountId, Balance, Signature};
 use ternoa_runtime::{
     constants::currency::UNIT, wasm_binary_unwrap, AuthorityDiscoveryConfig, BabeConfig,
     BalancesConfig, GenesisConfig, GrandpaConfig, ImOnlineConfig, SessionConfig, SessionKeys,
-    StakerStatus, StakingConfig, SudoConfig, SystemConfig,
+    StakerStatus, StakingConfig, SudoConfig, SystemConfig, TechnicalMembershipConfig,
 };
 
 type AccountPublic = <Signature as Verify>::Signer;
@@ -152,7 +152,14 @@ pub fn testnet_genesis(
 
         // Governance
         pallet_sudo: Some(SudoConfig {
-            key: root.unwrap_or(get_account_id_from_seed::<sr25519::Public>("Alice")),
+            key: root
+                .clone()
+                .unwrap_or(get_account_id_from_seed::<sr25519::Public>("Alice")),
+        }),
+        pallet_collective_Instance0: Some(Default::default()),
+        pallet_membership_Instance0: Some(TechnicalMembershipConfig {
+            members: vec![root.unwrap_or(get_account_id_from_seed::<sr25519::Public>("Alice"))],
+            phantom: Default::default(),
         }),
 
         // Ternoa

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -14,7 +14,7 @@ use ternoa_primitives::{AccountId, Balance, Signature};
 use ternoa_runtime::{
     constants::currency::UNIT, wasm_binary_unwrap, AuthorityDiscoveryConfig, BabeConfig,
     BalancesConfig, GenesisConfig, GrandpaConfig, ImOnlineConfig, SessionConfig, SessionKeys,
-    StakerStatus, StakingConfig, SudoConfig, SystemConfig, TechnicalMembershipConfig,
+    StakerStatus, StakingConfig, SystemConfig, TechnicalMembershipConfig,
 };
 
 type AccountPublic = <Signature as Verify>::Signer;
@@ -151,11 +151,6 @@ pub fn testnet_genesis(
         pallet_treasury: Default::default(),
 
         // Governance
-        pallet_sudo: Some(SudoConfig {
-            key: root
-                .clone()
-                .unwrap_or(get_account_id_from_seed::<sr25519::Public>("Alice")),
-        }),
         pallet_collective_Instance0: Some(Default::default()),
         pallet_membership_Instance0: Some(TechnicalMembershipConfig {
             members: vec![root.unwrap_or(get_account_id_from_seed::<sr25519::Public>("Alice"))],

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -33,7 +33,6 @@ pallet-randomness-collective-flip = { version = "3.0.0", default-features = fals
 pallet-scheduler = { version = "3.0.0", default-features = false }
 pallet-session = { version = "3.0.0", features = ["historical"], default-features = false }
 #pallet-session-benchmarking = { version = "3.0.0",  default-features = false, optional = true }
-pallet-sudo = { version = "3.0.0", default-features = false }
 pallet-timestamp = { version = "3.0.0", default-features = false }
 pallet-transaction-payment = { version = "3.0.0", default-features = false }
 pallet-transaction-payment-rpc-runtime-api = { version = "3.0.0", default-features = false }
@@ -86,7 +85,6 @@ std = [
 	"pallet-randomness-collective-flip/std",
 	"pallet-scheduler/std",
 	"pallet-session/std",
-	"pallet-sudo/std",
 	"pallet-timestamp/std",
 	"pallet-transaction-payment/std",
 	"pallet-transaction-payment-rpc-runtime-api/std",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -21,9 +21,11 @@ pallet-authorship = { version = "3.0.0", default-features = false }
 pallet-babe = { version = "3.0.0", default-features = false }
 pallet-balances = { version = "3.0.0", default-features = false }
 pallet-bounties = { version = "3.0.0", default-features = false }
+pallet-collective = { version = "3.0.0", default-features = false }
 pallet-curveless-staking = { version = "0.1.0", default-features = false }
 pallet-grandpa = { version = "3.0.0", default-features = false }
 pallet-im-online = { version = "3.0.0", default-features = false }
+pallet-membership = { version = "3.0.0", default-features = false }
 pallet-offences = { version = "3.0.0", default-features = false }
 #pallet-offences-benchmarking = { version = "3.0.0", default-features = false, optional = true }
 pallet-randomness-collective-flip = { version = "3.0.0", default-features = false }
@@ -73,9 +75,11 @@ std = [
 	"pallet-babe/std",
 	"pallet-balances/std",
 	"pallet-bounties/std",
+	"pallet-collective/std",
 	"pallet-curveless-staking/std",
 	"pallet-grandpa/std",
 	"pallet-im-online/std",
+	"pallet-membership/std",
 	"pallet-offences/std",
 	"pallet-randomness-collective-flip/std",
 	"pallet-scheduler/std",
@@ -115,6 +119,7 @@ runtime-benchmarks = [
 	"pallet-babe/runtime-benchmarks",
 	"pallet-balances/runtime-benchmarks",
 	"pallet-bounties/runtime-benchmarks",
+	"pallet-collective/runtime-benchmarks",
 	"pallet-curveless-staking/runtime-benchmarks",
 	"pallet-grandpa/runtime-benchmarks",
 	"pallet-im-online/runtime-benchmarks",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -25,6 +25,7 @@ pallet-collective = { version = "3.0.0", default-features = false }
 pallet-curveless-staking = { version = "0.1.0", default-features = false }
 pallet-grandpa = { version = "3.0.0", default-features = false }
 pallet-im-online = { version = "3.0.0", default-features = false }
+pallet-mandate = { version = "2.0.8", default-features = false }
 pallet-membership = { version = "3.0.0", default-features = false }
 pallet-offences = { version = "3.0.0", default-features = false }
 #pallet-offences-benchmarking = { version = "3.0.0", default-features = false, optional = true }
@@ -79,6 +80,7 @@ std = [
 	"pallet-curveless-staking/std",
 	"pallet-grandpa/std",
 	"pallet-im-online/std",
+	"pallet-mandate/std",
 	"pallet-membership/std",
 	"pallet-offences/std",
 	"pallet-randomness-collective-flip/std",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -76,6 +76,7 @@ construct_runtime!(
         Grandpa: pallet_grandpa::{Module, Call, Storage, Config, Event, ValidateUnsigned},
         Historical: pallet_session_historical::{Module},
         ImOnline: pallet_im_online::{Module, Call, Storage, Event<T>, ValidateUnsigned, Config<T>},
+        Mandate: pallet_mandate::{Module, Call, Event},
         Offences: pallet_offences::{Module, Call, Storage, Event},
         RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Module, Call, Storage},
         Scheduler: pallet_scheduler::{Module, Call, Storage, Event<T>},

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -30,6 +30,7 @@ use sp_version::RuntimeVersion;
 use ternoa_primitives::{AccountId, Balance, BlockNumber, Index, Signature};
 
 pub mod constants;
+mod migrations;
 mod pallets_core;
 mod pallets_economy;
 mod pallets_governance;
@@ -136,6 +137,7 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllModules,
+    migrations::SudoToTechComm,
 >;
 
 impl_runtime_apis! {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -83,6 +83,8 @@ construct_runtime!(
         Staking: pallet_curveless_staking::{Module, Call, Config<T>, Storage, Event<T>, ValidateUnsigned},
         Sudo: pallet_sudo::{Module, Call, Config<T>, Storage, Event<T>},
         System: frame_system::{Module, Call, Config, Storage, Event<T>},
+        TechnicalCommittee: pallet_collective::<Instance0>::{Module, Call, Storage, Origin<T>, Event<T>, Config<T>},
+        TechnicalMembership: pallet_membership::<Instance0>::{Module, Call, Storage, Event<T>, Config<T>},
         Treasury: pallet_treasury::{Module, Call, Storage, Config, Event<T>},
         TransactionPayment: pallet_transaction_payment::{Module, Storage},
         Utility: pallet_utility::{Module, Call, Storage, Event},
@@ -357,6 +359,7 @@ impl_runtime_apis! {
             add_benchmark!(params, batches, pallet_bounties, Bounties);
             add_benchmark!(params, batches, pallet_grandpa, Grandpa);
             add_benchmark!(params, batches, pallet_im_online, ImOnline);
+            add_benchmark!(params, batches, pallet_collective, TechnicalCommittee);
             //add_benchmark!(params, batches, pallet_offences, OffencesBench::<Runtime>);
             add_benchmark!(params, batches, pallet_scheduler, Scheduler);
             //add_benchmark!(params, batches, pallet_session, SessionBench::<Runtime>);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -82,7 +82,6 @@ construct_runtime!(
         Scheduler: pallet_scheduler::{Module, Call, Storage, Event<T>},
         Session: pallet_session::{Module, Call, Storage, Event, Config<T>},
         Staking: pallet_curveless_staking::{Module, Call, Config<T>, Storage, Event<T>, ValidateUnsigned},
-        Sudo: pallet_sudo::{Module, Call, Config<T>, Storage, Event<T>},
         System: frame_system::{Module, Call, Config, Storage, Event<T>},
         TechnicalCommittee: pallet_collective::<Instance0>::{Module, Call, Storage, Origin<T>, Event<T>, Config<T>},
         TechnicalMembership: pallet_membership::<Instance0>::{Module, Call, Storage, Event<T>, Config<T>},

--- a/runtime/src/migrations.rs
+++ b/runtime/src/migrations.rs
@@ -25,20 +25,14 @@ impl OnRuntimeUpgrade for SudoToTechComm {
         members_storage_key.extend_from_slice(&Twox128::hash(b"Instance0Membership"));
         members_storage_key.extend_from_slice(&Twox128::hash(b"Members"));
 
-        let mut prime_storage_key = Vec::new();
-        prime_storage_key.extend_from_slice(&Twox128::hash(b"Instance0Membership"));
-        prime_storage_key.extend_from_slice(&Twox128::hash(b"Prime"));
-
         if let Some(sudo_key) = unhashed::get::<AccountId>(&sudo_key_storage_key) {
             // Configure the tech membership with the old sudo key
             let mut members = Vec::new();
             members.push(sudo_key.clone());
             unhashed::put(&members_storage_key, &members);
-            unhashed::put(&prime_storage_key, &sudo_key);
 
             // Let the tech committee pallet know about the membership changes
             <<Runtime as pallet_membership::Config<TechnicalCollectiveMembers>>::MembershipInitialized as InitializeMembers<AccountId>>::initialize_members(&members);
-            <<Runtime as pallet_membership::Config<TechnicalCollectiveMembers>>::MembershipChanged as ChangeMembers<AccountId>>::set_prime(Some(sudo_key));
         }
 
         // Clean sudo storage

--- a/runtime/src/migrations.rs
+++ b/runtime/src/migrations.rs
@@ -1,0 +1,52 @@
+use crate::{
+    pallets_core::RuntimeBlockWeights, pallets_governance::TechnicalCollectiveMembers, Runtime,
+};
+use frame_support::{
+    debug,
+    storage::unhashed,
+    traits::{ChangeMembers, InitializeMembers, OnRuntimeUpgrade},
+    weights::Weight,
+    StorageHasher, Twox128,
+};
+use sp_std::vec::Vec;
+use ternoa_primitives::AccountId;
+
+pub struct SudoToTechComm;
+impl OnRuntimeUpgrade for SudoToTechComm {
+    fn on_runtime_upgrade() -> Weight {
+        debug::RuntimeLogger::init();
+        debug::print!("🕊️ Starting sudo migration...");
+
+        let mut sudo_key_storage_key = Vec::new();
+        sudo_key_storage_key.extend_from_slice(&Twox128::hash(b"Sudo"));
+        sudo_key_storage_key.extend_from_slice(&Twox128::hash(b"Key"));
+
+        let mut members_storage_key = Vec::new();
+        members_storage_key.extend_from_slice(&Twox128::hash(b"Instance0Membership"));
+        members_storage_key.extend_from_slice(&Twox128::hash(b"Members"));
+
+        let mut prime_storage_key = Vec::new();
+        prime_storage_key.extend_from_slice(&Twox128::hash(b"Instance0Membership"));
+        prime_storage_key.extend_from_slice(&Twox128::hash(b"Prime"));
+
+        if let Some(sudo_key) = unhashed::get::<AccountId>(&sudo_key_storage_key) {
+            // Configure the tech membership with the old sudo key
+            let mut members = Vec::new();
+            members.push(sudo_key.clone());
+            unhashed::put(&members_storage_key, &members);
+            unhashed::put(&prime_storage_key, &sudo_key);
+
+            // Let the tech committee pallet know about the membership changes
+            <<Runtime as pallet_membership::Config<TechnicalCollectiveMembers>>::MembershipInitialized as InitializeMembers<AccountId>>::initialize_members(&members);
+            <<Runtime as pallet_membership::Config<TechnicalCollectiveMembers>>::MembershipChanged as ChangeMembers<AccountId>>::set_prime(Some(sudo_key));
+        }
+
+        // Clean sudo storage
+        unhashed::kill(&sudo_key_storage_key);
+
+        debug::print!("🕊️ Sudo migration done");
+
+        // Keep things simple, take a full block to execute when the migration is deployed
+        RuntimeBlockWeights::get().max_block
+    }
+}

--- a/runtime/src/pallets_governance.rs
+++ b/runtime/src/pallets_governance.rs
@@ -1,6 +1,44 @@
-use crate::{Call, Event, Runtime};
+use crate::{constants::time::DAYS, Call, Event, Origin, Runtime, TechnicalCommittee};
+use frame_support::parameter_types;
+use sp_core::u32_trait::{_1, _2};
+use ternoa_primitives::{AccountId, BlockNumber};
 
 impl pallet_sudo::Config for Runtime {
     type Event = Event;
     type Call = Call;
+}
+
+// Shared parameters with all collectives / committees
+parameter_types! {
+    pub const MotionDuration: BlockNumber = 2 * DAYS;
+    pub const MaxProposals: u32 = 100;
+    pub const MaxMembers: u32 = 50;
+}
+
+// --- Technical committee
+pub type TechnicalCollective = pallet_collective::Instance0;
+pub type TechnicalCollectiveMembers = pallet_membership::Instance0;
+pub type MoreThanHalfOfTheTechnicalCollective =
+    pallet_collective::EnsureProportionMoreThan<_1, _2, AccountId, TechnicalCollective>;
+
+impl pallet_collective::Config<TechnicalCollective> for Runtime {
+    type Origin = Origin;
+    type Proposal = Call;
+    type Event = Event;
+    type MotionDuration = MotionDuration;
+    type MaxProposals = MaxProposals;
+    type WeightInfo = ();
+    type MaxMembers = MaxMembers;
+    type DefaultVote = pallet_collective::PrimeDefaultVote;
+}
+
+impl pallet_membership::Config<TechnicalCollectiveMembers> for Runtime {
+    type Event = Event;
+    type AddOrigin = MoreThanHalfOfTheTechnicalCollective;
+    type RemoveOrigin = MoreThanHalfOfTheTechnicalCollective;
+    type SwapOrigin = MoreThanHalfOfTheTechnicalCollective;
+    type ResetOrigin = MoreThanHalfOfTheTechnicalCollective;
+    type PrimeOrigin = MoreThanHalfOfTheTechnicalCollective;
+    type MembershipInitialized = TechnicalCommittee;
+    type MembershipChanged = TechnicalCommittee;
 }

--- a/runtime/src/pallets_governance.rs
+++ b/runtime/src/pallets_governance.rs
@@ -3,11 +3,6 @@ use frame_support::parameter_types;
 use sp_core::u32_trait::{_1, _2};
 use ternoa_primitives::{AccountId, BlockNumber};
 
-impl pallet_sudo::Config for Runtime {
-    type Event = Event;
-    type Call = Call;
-}
-
 // Shared parameters with all collectives / committees
 parameter_types! {
     pub const MotionDuration: BlockNumber = 2 * DAYS;

--- a/runtime/src/pallets_governance.rs
+++ b/runtime/src/pallets_governance.rs
@@ -42,3 +42,9 @@ impl pallet_membership::Config<TechnicalCollectiveMembers> for Runtime {
     type MembershipInitialized = TechnicalCommittee;
     type MembershipChanged = TechnicalCommittee;
 }
+
+impl pallet_mandate::Config for Runtime {
+    type Event = Event;
+    type Call = Call;
+    type ExternalOrigin = MoreThanHalfOfTheTechnicalCollective;
+}

--- a/runtime/src/version.rs
+++ b/runtime/src/version.rs
@@ -16,7 +16,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // and set impl_version to 0. If only runtime
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
-    spec_version: 12,
+    spec_version: 13,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Explainer

This PR replaces the `sudo` pallet with a technical committee which can be optionally composed of multiple members.
By default, we only approve proposals 50% + 1 of the committee members are voting yes.

We have also included some runtime migrations to support upgrading from a live chain to this latest runtime version.

## Testing Instructions

### Runtime Upgrade
1. You need to start a local node with a previous runtime version (just use the one in the `main` branch)
2. You need to build this new runtime, you could use `cargo build -p ternoa-runtime` to do so
3. You need to upgrade the local chain with the non upgraded node. To do so, head over on Polkadot JS to `developer > sudo` and submit the extrinsic `system.setCode`. When it asks for a file you can drag and drop the content of `target/debug/wbuild/ternoa-runtime/ternoa_runtime.compact.wasm`. Make sure to tick the last line ("Unchecked Weight") and give it an arbitrary number.
4. Once the transaction goes through, you should have a new tab in `Governance` named `Tech. Comm`, when you click on it you should the previous key `Alice` is a member of the committee.

### Privileged Calls
Assuming you have a chain running with the runtime from this (either do the uprgade testing flow or start a new development node) you can:
1. Head over to the `Tech. Comm` tab and click on `Proposals`
2. Click the button to submit a new proposal
3. Set the extrinsic to `mandate.apply(system.remark(0x00))`
4. Submit, you should see an event `RootOp` was triggered with success in the `Explorer` tab

### Adding members to the committee
Only the committee can add members to itself, you can submit the following extrinsic from it: `technicalMembership.addMember(BOB)` for instance.

Once you have added at least one member, try to submit a new proposal. It should now ask you to vote on it.
