### PR TITLE
switch from account it to multi address

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -105,7 +105,7 @@ construct_runtime!(
 );
 
 /// The address format for describing accounts.
-pub type Address = AccountId;
+pub type Address = sp_runtime::MultiAddress<AccountId, ()>;
 /// Block header type as expected by this runtime.
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 /// Block type as expected by this runtime.

--- a/runtime/src/pallets_core.rs
+++ b/runtime/src/pallets_core.rs
@@ -12,7 +12,7 @@ use frame_system::{
 };
 use sp_runtime::{
     generic,
-    traits::{BlakeTwo256, IdentityLookup},
+    traits::{AccountIdLookup, BlakeTwo256},
     Perbill,
 };
 use sp_version::RuntimeVersion;
@@ -68,7 +68,7 @@ impl frame_system::Config for Runtime {
     type Hash = Hash;
     type Hashing = BlakeTwo256;
     type AccountId = AccountId;
-    type Lookup = IdentityLookup<AccountId>;
+    type Lookup = AccountIdLookup<AccountId, ()>;
     type Header = generic::Header<BlockNumber, BlakeTwo256>;
     type Event = Event;
     type BlockHashCount = BlockHashCount;

--- a/types.json
+++ b/types.json
@@ -1,6 +1,6 @@
 {
     "AccountDataOf": "AccountData",
-    "Address": "AccountId",
+    "Address": "MultiAddress",
     "NFTId": "u32",
     "NFTIdOf": "NFTId",
     "NFTSeriesId": "u32",
@@ -15,7 +15,7 @@
         "series_id": "NFTSeriesId",
         "is_capsule": "bool"
     },
-    "LookupSource": "AccountId",
+    "LookupSource": "MultiAddress",
     "NFTSeriesDetails": {
         "owner": "AccountId",
         "nfts": "Vec<NFTId>"


### PR DESCRIPTION
SCS's substrate api client expects us to use the `MultiAddress` type, not full on `AccountId`. Changes that for compatibility purposes.
