### PR TITLE
rename pallets to new instance names

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -27,6 +27,7 @@ use sp_version::RuntimeVersion;
 use ternoa_primitives::{AccountId, Balance, BlockNumber, Index, Signature};
 
 pub mod constants;
+mod migrations;
 mod pallets_core;
 mod pallets_economy;
 mod pallets_governance;
@@ -141,6 +142,7 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPallets,
+    migrations::Instances,
 >;
 
 impl_runtime_apis! {

--- a/runtime/src/migrations.rs
+++ b/runtime/src/migrations.rs
@@ -1,0 +1,25 @@
+use crate::pallets_core::RuntimeBlockWeights;
+use frame_support::{storage::migration::move_pallet, traits::OnRuntimeUpgrade, weights::Weight};
+
+pub(crate) const LOG_TARGET: &'static str = "migration";
+
+pub struct Instances;
+impl OnRuntimeUpgrade for Instances {
+    fn on_runtime_upgrade() -> Weight {
+        sp_tracing::debug!(target: LOG_TARGET, "🕊️ Starting instances migration...");
+
+        move_pallet(
+            b"TechnicalCommitteeInstance0",
+            b"TechnicalCommitteeDefaultInstance",
+        );
+        move_pallet(
+            b"TechnicalMembershipInstance0",
+            b"TechnicalMembershipDefaultInstance",
+        );
+
+        sp_tracing::debug!(target: LOG_TARGET, "🕊️ Instances migration done");
+
+        // Keep things simple, take a full block to execute when the migration is deployed
+        RuntimeBlockWeights::get().max_block
+    }
+}


### PR DESCRIPTION
Last substrate version bump changed the ways we have to specify pallet's instances. We used to use `Instance0` but it was deprecated and we had to change it to `DefaultInstance`. Which means that we have to rename some storage elements.
