### PR TITLE
Add skip ra feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2328,7 +2328,7 @@ dependencies = [
 [[package]]
 name = "ias-verify"
 version = "0.1.4"
-source = "git+https://github.com/scs/pallet-substratee-registry#860097f21141fb6cd5eb455d8ca9e8adb7031c7d"
+source = "git+https://github.com/scs/pallet-substratee-registry?branch=bh-skip-ra-feature#ec2d283c90fb12639abc1e373f200782a2a0b2b2"
 dependencies = [
  "base64 0.11.0",
  "chrono",
@@ -4098,7 +4098,7 @@ dependencies = [
 [[package]]
 name = "pallet-substratee-registry"
 version = "0.8.0"
-source = "git+https://github.com/scs/pallet-substratee-registry#860097f21141fb6cd5eb455d8ca9e8adb7031c7d"
+source = "git+https://github.com/scs/pallet-substratee-registry?branch=bh-skip-ra-feature#ec2d283c90fb12639abc1e373f200782a2a0b2b2"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2328,7 +2328,7 @@ dependencies = [
 [[package]]
 name = "ias-verify"
 version = "0.1.4"
-source = "git+https://github.com/scs/pallet-substratee-registry?branch=bh-skip-ra-feature#ec2d283c90fb12639abc1e373f200782a2a0b2b2"
+source = "git+https://github.com/scs/pallet-substratee-registry?branch=bh-skip-ra-feature#1c60c489744714a0fa64be17e55b0bd0081f9473"
 dependencies = [
  "base64 0.11.0",
  "chrono",
@@ -4098,7 +4098,7 @@ dependencies = [
 [[package]]
 name = "pallet-substratee-registry"
 version = "0.8.0"
-source = "git+https://github.com/scs/pallet-substratee-registry?branch=bh-skip-ra-feature#ec2d283c90fb12639abc1e373f200782a2a0b2b2"
+source = "git+https://github.com/scs/pallet-substratee-registry?branch=bh-skip-ra-feature#1c60c489744714a0fa64be17e55b0bd0081f9473"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -17,6 +17,9 @@ cli = [
 	"ternoa-executor/wasmi-errno",
 ]
 
+# allow workers to register without remote attestation for dev purposes
+skip-ias-check = ["ternoa-runtime/skip-ias-check"]
+
 [package.metadata.wasm-pack.profile.release]
 # `wasm-opt` has some problems on linux, see
 # https://github.com/rustwasm/wasm-pack/issues/781 etc.

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -33,7 +33,7 @@ pallet-randomness-collective-flip = { git = "https://github.com/paritytech/subst
 pallet-scheduler = { git = "https://github.com/paritytech/substrate/", default-features = false }
 pallet-session = { git = "https://github.com/paritytech/substrate/", features = ["historical"], default-features = false }
 #pallet-session-benchmarking = { git = "https://github.com/paritytech/substrate/",  default-features = false, optional = true }
-pallet-substratee-registry = { git = "https://github.com/scs/pallet-substratee-registry", default-features = false }
+pallet-substratee-registry = { git = "https://github.com/scs/pallet-substratee-registry", default-features = false, branch = "bh-skip-ra-feature"}
 pallet-sudo = { git = "https://github.com/paritytech/substrate/", default-features = false }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate/", default-features = false }
 pallet-transaction-payment = { git = "https://github.com/paritytech/substrate/", default-features = false }
@@ -67,6 +67,7 @@ substrate-wasm-builder = { git = "https://github.com/paritytech/substrate/" }
 
 [features]
 default = ["std"]
+skip-ias-check = ["pallet-substratee-registry/skip-ias-check"]
 std = [
 	"codec/std",
 	"frame-executive/std",


### PR DESCRIPTION
Allows to build the node in  `cargo build --release --features skip-ias-check` mode, allowing workes (enlcaves) to register without a valid intel remote attestion, which is not available for workers running in simulation node.

This is neccessary four our demo script running within docker (SW mode only)

ofc a merge is not necessary, we can also run the demo script on this branch of the node. Leaving the choice to you.